### PR TITLE
Spring Boot 3 Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ Last deployed version: **1.16**
 `mvn clean verify` when you want to be sure, that whole project just works  
 
 ### Release Notes [Development v2.7.8]
-— TBD
+— Modification: updated Springboot to version 3.2.5 and all related dependencies

--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ Last deployed version: **1.16**
 `mvn clean verify` when you want to be sure, that whole project just works  
 
 ### Release Notes [Development v2.7.8]
-— Modification: updated Springboot to version 3.2.5 and all related dependencies
-— Deletion: possibility of using any string as JWT secret key. Generate a new HS256 key
+— Modification: Spring Boot updated to version 3.2.5 (and all related dependencies to match Spring Boot BOM)
+— Modification: jjwt updated to 0.12.5 (you have to generate a new HS265 secret key and truncate sessions table)

--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@ Last deployed version: **1.16**
 
 ### Release Notes [Development v2.7.8]
 — Modification: updated Springboot to version 3.2.5 and all related dependencies
+— Deletion: possibility of using any string as JWT secret key. Generate a new HS256 key

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,6 @@
         <version.dependency.feign>12.3</version.dependency.feign>
         <version.dependency.geoip2>4.0.1</version.dependency.geoip2>
         <version.dependency.jackson>2.15.4</version.dependency.jackson>
-        <version.dependency.jakarta>4.0.2</version.dependency.jakarta>
         <version.dependency.jasypt>3.0.5</version.dependency.jasypt>
         <version.dependency.jcolor>5.5.1</version.dependency.jcolor>
         <version.dependency.jsonwebtoken>0.12.5</version.dependency.jsonwebtoken>
@@ -136,12 +135,6 @@
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-core</artifactId>
                 <version>${version.dependency.liquibase}</version>
-            </dependency>
-            <!-- j8 -> j11 migration, @ObjectMapper related, API, javax.xml.bind module -->
-            <dependency>
-                <groupId>jakarta.xml.bind</groupId>
-                <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>${version.dependency.jakarta}</version>
             </dependency>
             <!-- HTTP Client: Feign-->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <version.dependency.jsonwebtoken>0.9.1</version.dependency.jsonwebtoken>
         <version.dependency.liquibase>4.24.0</version.dependency.liquibase>
         <version.dependency.lombok>1.18.26</version.dependency.lombok>
-        <version.dependency.postresql.hibernate.types>2.21.1</version.dependency.postresql.hibernate.types>
+        <version.dependency.postresql.hibernate.utils>3.7.4</version.dependency.postresql.hibernate.utils>
         <version.dependency.springframework.boot>3.2.5</version.dependency.springframework.boot>
         <!-- dependencies, scope == test -->
         <version.dependency.assertj>3.24.2</version.dependency.assertj>
@@ -125,11 +125,11 @@
                 <artifactId>jjwt</artifactId>
                 <version>${version.dependency.jsonwebtoken}</version>
             </dependency>
-            <!-- PostgreSQL -->
+            <!-- PostgreSQL Types + Hibernate Utils -->
             <dependency>
-                <groupId>com.vladmihalcea</groupId>
-                <artifactId>hibernate-types-52</artifactId>
-                <version>${version.dependency.postresql.hibernate.types}</version>
+                <groupId>io.hypersistence</groupId>
+                <artifactId>hypersistence-utils-hibernate-63</artifactId>
+                <version>${version.dependency.postresql.hibernate.utils}</version>
             </dependency>
             <!-- Liquibase -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
                 <artifactId>jjwt</artifactId>
                 <version>${version.dependency.jsonwebtoken}</version>
             </dependency>
-            <!-- PostgreSQL Types + Hibernate Utils -->
+            <!-- PostgreSQL Types -->
             <dependency>
                 <groupId>io.hypersistence</groupId>
                 <artifactId>hypersistence-utils-hibernate-63</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <version.dependency.jakarta>4.0.2</version.dependency.jakarta>
         <version.dependency.jasypt>3.0.5</version.dependency.jasypt>
         <version.dependency.jcolor>5.5.1</version.dependency.jcolor>
-        <version.dependency.jsonwebtoken>0.9.1</version.dependency.jsonwebtoken>
+        <version.dependency.jsonwebtoken>0.12.5</version.dependency.jsonwebtoken>
         <version.dependency.liquibase>4.24.0</version.dependency.liquibase>
         <version.dependency.lombok>1.18.26</version.dependency.lombok>
         <version.dependency.postresql.hibernate.utils>3.7.4</version.dependency.postresql.hibernate.utils>
@@ -515,6 +515,8 @@
                     <forceJavacCompilerUse>true</forceJavacCompilerUse>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
+                    <!-- https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-6.x#parameter-name-retention  -->
+                    <parameters>true</parameters>
                 </configuration>
             </plugin>
             <!-- Copy Dependency: Lombok (Sonar Purposes) -->

--- a/pom.xml
+++ b/pom.xml
@@ -68,23 +68,22 @@
         <!-- dependencies, scope == compile -->
         <version.dependency.apache.collections>4.4</version.dependency.apache.collections>
         <version.dependency.browscap>1.4.0</version.dependency.browscap>
-        <version.dependency.common.codec>1.15</version.dependency.common.codec>
+        <version.dependency.common.codec>1.16.1</version.dependency.common.codec>
         <version.dependency.feign>12.3</version.dependency.feign>
         <version.dependency.geoip2>4.0.1</version.dependency.geoip2>
-        <version.dependency.jackson>2.15.0</version.dependency.jackson>
-        <version.dependency.jakarta>2.3.3</version.dependency.jakarta>
+        <version.dependency.jackson>2.15.4</version.dependency.jackson>
+        <version.dependency.jakarta>4.0.2</version.dependency.jakarta>
         <version.dependency.jasypt>3.0.5</version.dependency.jasypt>
         <version.dependency.jcolor>5.5.1</version.dependency.jcolor>
         <version.dependency.jsonwebtoken>0.9.1</version.dependency.jsonwebtoken>
-        <version.dependency.liquibase>4.21.1</version.dependency.liquibase>
+        <version.dependency.liquibase>4.24.0</version.dependency.liquibase>
         <version.dependency.lombok>1.18.26</version.dependency.lombok>
         <version.dependency.postresql.hibernate.types>2.21.1</version.dependency.postresql.hibernate.types>
-        <version.dependency.springframework.boot>2.7.18</version.dependency.springframework.boot>
-        <version.dependency.tomcat.embed>9.0.74</version.dependency.tomcat.embed>
+        <version.dependency.springframework.boot>3.2.5</version.dependency.springframework.boot>
         <!-- dependencies, scope == test -->
         <version.dependency.assertj>3.24.2</version.dependency.assertj>
-        <version.dependency.jsonpath>2.8.0</version.dependency.jsonpath>
-        <version.dependency.junit>5.9.3</version.dependency.junit>
+        <version.dependency.jsonpath>2.9.0</version.dependency.jsonpath>
+        <version.dependency.junit>5.10.2</version.dependency.junit>
         <version.dependency.testcontainers>1.19.7</version.dependency.testcontainers>
         <!-- plugins -->
         <version.plugin.build.helper>3.4.0</version.plugin.build.helper>
@@ -190,12 +189,6 @@
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
                 <version>${version.dependency.common.codec}</version>
-            </dependency>
-            <!-- Tomcat: Cookie, CacheHttpRequests -->
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-core</artifactId>
-                <version>${version.dependency.tomcat.embed}</version>
             </dependency>
             <!-- JColor (console asserts) -->
             <dependency>

--- a/tech1-framework-b2b-base-security-jwt-websockets/src/main/java/io/tech1/framework/b2b/base/security/jwt/websockets/configurations/ApplicationBaseSecurityJwtWebsockets.java
+++ b/tech1-framework-b2b-base-security-jwt-websockets/src/main/java/io/tech1/framework/b2b/base/security/jwt/websockets/configurations/ApplicationBaseSecurityJwtWebsockets.java
@@ -4,6 +4,7 @@ import io.tech1.framework.b2b.base.security.jwt.websockets.handshakes.CsrfInterc
 import io.tech1.framework.b2b.base.security.jwt.websockets.handshakes.SecurityHandshakeHandler;
 import io.tech1.framework.domain.base.PropertyId;
 import io.tech1.framework.properties.ApplicationFrameworkProperties;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,8 +15,6 @@ import org.springframework.security.config.annotation.web.messaging.MessageSecur
 import org.springframework.security.config.annotation.web.socket.AbstractSecurityWebSocketMessageBrokerConfigurer;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
-
-import javax.annotation.PostConstruct;
 
 /**
  * <a href="https://docs.spring.io/spring-security/reference/servlet/integrations/websocket.html">Documentation #1</a>
@@ -31,6 +30,7 @@ import javax.annotation.PostConstruct;
 })
 @EnableWebSocketMessageBroker
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
+// TODO [VB] deprecated
 public class ApplicationBaseSecurityJwtWebsockets extends AbstractSecurityWebSocketMessageBrokerConfigurer {
 
     // Handshakes
@@ -53,6 +53,7 @@ public class ApplicationBaseSecurityJwtWebsockets extends AbstractSecurityWebSoc
                 .withSockJS();
     }
 
+    // TODO [VB] deprecated
     @Override
     protected void configureInbound(MessageSecurityMetadataSourceRegistry registry) {
         registry.anyMessage().authenticated();

--- a/tech1-framework-b2b-base-security-jwt-websockets/src/main/java/io/tech1/framework/b2b/base/security/jwt/websockets/configurations/ApplicationBaseSecurityJwtWebsockets.java
+++ b/tech1-framework-b2b-base-security-jwt-websockets/src/main/java/io/tech1/framework/b2b/base/security/jwt/websockets/configurations/ApplicationBaseSecurityJwtWebsockets.java
@@ -33,7 +33,7 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
  * </a>
  * <p>
  * <a href="https://github.com/jhipster/generator-jhipster/issues/20404">
- * Migrate to Spring Security 6's @EnableWebSocketSecurity
+ * Migrate to Spring Security 6's @EnableWebSocketSecurity (it is not possible to disable CSRF currently)
  * </a>
  */
 // idea - reconnect flow: https://stackoverflow.com/questions/53244720/spring-websocket-stomp-exception-handling

--- a/tech1-framework-b2b-base-security-jwt-websockets/src/main/java/io/tech1/framework/b2b/base/security/jwt/websockets/configurations/ApplicationBaseSecurityJwtWebsockets.java
+++ b/tech1-framework-b2b-base-security-jwt-websockets/src/main/java/io/tech1/framework/b2b/base/security/jwt/websockets/configurations/ApplicationBaseSecurityJwtWebsockets.java
@@ -63,7 +63,7 @@ public class ApplicationBaseSecurityJwtWebsockets extends AbstractSecurityWebSoc
     }
 
     @Override
-    public void configureInbound(MessageSecurityMetadataSourceRegistry registry) {
+    protected void configureInbound(MessageSecurityMetadataSourceRegistry registry) {
         registry.anyMessage().authenticated();
     }
 

--- a/tech1-framework-b2b-base-security-jwt-websockets/src/test/java/io/tech1/framework/b2b/base/security/jwt/websockets/configurations/ApplicationBaseSecurityJwtWebsocketsTest.java
+++ b/tech1-framework-b2b-base-security-jwt-websockets/src/test/java/io/tech1/framework/b2b/base/security/jwt/websockets/configurations/ApplicationBaseSecurityJwtWebsocketsTest.java
@@ -96,7 +96,7 @@ class ApplicationBaseSecurityJwtWebsocketsTest {
 
         // Assert
         assertThat(methods)
-                .hasSize(24)
+                .hasSize(32)
                 .contains("registerStompEndpoints")
                 .contains("configureMessageBroker");
     }

--- a/tech1-framework-b2b-base-security-jwt-websockets/src/test/java/io/tech1/framework/b2b/base/security/jwt/websockets/configurations/ApplicationBaseSecurityJwtWebsocketsTest.java
+++ b/tech1-framework-b2b-base-security-jwt-websockets/src/test/java/io/tech1/framework/b2b/base/security/jwt/websockets/configurations/ApplicationBaseSecurityJwtWebsocketsTest.java
@@ -143,12 +143,4 @@ class ApplicationBaseSecurityJwtWebsocketsTest {
         );
     }
 
-    @Test
-    void sameOriginDisabledTest() {
-        // Act
-        var actual = this.componentUnderTest.sameOriginDisabled();
-
-        // Assert
-        assertThat(actual).isFalse();
-    }
 }

--- a/tech1-framework-b2b-base-security-jwt-websockets/src/test/java/io/tech1/framework/b2b/base/security/jwt/websockets/configurations/ApplicationBaseSecurityJwtWebsocketsTest.java
+++ b/tech1-framework-b2b-base-security-jwt-websockets/src/test/java/io/tech1/framework/b2b/base/security/jwt/websockets/configurations/ApplicationBaseSecurityJwtWebsocketsTest.java
@@ -96,7 +96,7 @@ class ApplicationBaseSecurityJwtWebsocketsTest {
 
         // Assert
         assertThat(methods)
-                .hasSize(31)
+                .hasSize(24)
                 .contains("registerStompEndpoints")
                 .contains("configureMessageBroker");
     }

--- a/tech1-framework-b2b-base-security-jwt-websockets/src/test/java/io/tech1/framework/b2b/base/security/jwt/websockets/handshakes/CsrfInterceptorHandshakeTest.java
+++ b/tech1-framework-b2b-base-security-jwt-websockets/src/test/java/io/tech1/framework/b2b/base/security/jwt/websockets/handshakes/CsrfInterceptorHandshakeTest.java
@@ -22,7 +22,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 import org.springframework.web.socket.WebSocketHandler;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/tech1-framework-b2b-base-security-jwt-websockets/src/test/java/io/tech1/framework/b2b/base/security/jwt/websockets/handshakes/SecurityHandshakeHandlerTest.java
+++ b/tech1-framework-b2b-base-security-jwt-websockets/src/test/java/io/tech1/framework/b2b/base/security/jwt/websockets/handshakes/SecurityHandshakeHandlerTest.java
@@ -27,7 +27,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 import org.springframework.web.socket.WebSocketHandler;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/assistants/current/CurrentSessionAssistant.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/assistants/current/CurrentSessionAssistant.java
@@ -8,7 +8,7 @@ import io.tech1.framework.b2b.base.security.jwt.domain.security.CurrentClientUse
 import io.tech1.framework.domain.base.Username;
 import io.tech1.framework.domain.exceptions.tokens.AccessTokenNotFoundException;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 public interface CurrentSessionAssistant {
     Username getCurrentUsername();

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/assistants/current/base/BaseCurrentSessionAssistant.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/assistants/current/base/BaseCurrentSessionAssistant.java
@@ -20,7 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.Set;
 

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/configurations/ApplicationBaseSecurityJwt.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/configurations/ApplicationBaseSecurityJwt.java
@@ -28,7 +28,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import static io.tech1.framework.domain.base.AbstractAuthority.*;
 import static org.springframework.http.HttpMethod.*;
@@ -96,6 +96,7 @@ public class ApplicationBaseSecurityJwt {
         return this.abstractApplicationSecurityJwtConfigurer::configure;
     }
 
+    // TODO [VB] deprecated
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         var basePathPrefix = this.applicationFrameworkProperties.getMvcConfigs().getFrameworkBasePathPrefix();

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/configurations/ApplicationBaseSecurityJwt.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/configurations/ApplicationBaseSecurityJwt.java
@@ -144,11 +144,11 @@ public class ApplicationBaseSecurityJwt {
                     .requestMatchers(basePathPrefix + "/**").authenticated();
 
             authorizeHttpRequests.requestMatchers("/actuator/**").permitAll();
-
-            // WARNING: anyRequest().authenticated() must be called the last in the project that uses tech1-framework
         });
 
         this.abstractApplicationSecurityJwtConfigurer.configure(http);
+
+        http.authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests.anyRequest().authenticated());
 
         return http.build();
     }

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/configurations/ApplicationBaseSecurityJwt.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/configurations/ApplicationBaseSecurityJwt.java
@@ -145,7 +145,7 @@ public class ApplicationBaseSecurityJwt {
 
             authorizeHttpRequests.requestMatchers("/actuator/**").permitAll();
 
-            authorizeHttpRequests.anyRequest().authenticated();
+            // WARNING: anyRequest().authenticated() must be called the last in the project that uses tech1-framework
         });
 
         this.abstractApplicationSecurityJwtConfigurer.configure(http);

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/configurations/ApplicationBaseSecurityJwt.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/configurations/ApplicationBaseSecurityJwt.java
@@ -114,32 +114,38 @@ public class ApplicationBaseSecurityJwt {
                     .sessionManagement()
                     .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
-        var urlRegistry = http.authorizeRequests();
-        urlRegistry.antMatchers(POST, basePathPrefix + "/authentication/login").permitAll();
-        urlRegistry.antMatchers(POST, basePathPrefix +"/authentication/logout").permitAll();
-        urlRegistry.antMatchers(POST, basePathPrefix + "/authentication/refreshToken").permitAll();
-        urlRegistry.antMatchers(GET, basePathPrefix + "/session/current").authenticated();
-        urlRegistry.antMatchers(POST, basePathPrefix + "/registration/register1").denyAll();
-        urlRegistry.antMatchers(POST, basePathPrefix + "/user/update1").denyAll();
-        urlRegistry.antMatchers(POST, basePathPrefix + "/user/update2").authenticated();
-        urlRegistry.antMatchers(POST, basePathPrefix + "/user/changePassword1").denyAll();
+        http.authorizeHttpRequests(authorizeHttpRequests -> {
+            authorizeHttpRequests
+                    .requestMatchers(POST, basePathPrefix + "/authentication/login").permitAll()
+                    .requestMatchers(POST, basePathPrefix +"/authentication/logout").permitAll()
+                    .requestMatchers(POST, basePathPrefix + "/authentication/refreshToken").permitAll()
+                    .requestMatchers(GET, basePathPrefix + "/session/current").authenticated()
+                    .requestMatchers(POST, basePathPrefix + "/registration/register1").denyAll()
+                    .requestMatchers(POST, basePathPrefix + "/user/update1").denyAll()
+                    .requestMatchers(POST, basePathPrefix + "/user/update2").authenticated()
+                    .requestMatchers(POST, basePathPrefix + "/user/changePassword1").denyAll();
 
-        if (this.applicationFrameworkProperties.getSecurityJwtConfigs().getEssenceConfigs().getInvitationCodes().isEnabled()) {
-            urlRegistry.antMatchers(GET, basePathPrefix + "/invitationCode").hasAuthority(INVITATION_CODE_READ);
-            urlRegistry.antMatchers(POST, basePathPrefix + "/invitationCode").hasAuthority(INVITATION_CODE_WRITE);
-            urlRegistry.antMatchers(DELETE, basePathPrefix + "/invitationCode/{invitationCodeId}").hasAuthority(INVITATION_CODE_WRITE);
-        } else {
-            urlRegistry.antMatchers( basePathPrefix + "/invitationCode/**").denyAll();
-        }
-        urlRegistry.antMatchers(basePathPrefix + "/hardware/**").authenticated();
-        urlRegistry.antMatchers(basePathPrefix + "/superadmin/**").hasAuthority(SUPERADMIN);
-        urlRegistry.antMatchers(basePathPrefix + "/**").authenticated();
+            if (this.applicationFrameworkProperties.getSecurityJwtConfigs().getEssenceConfigs().getInvitationCodes().isEnabled()) {
+                authorizeHttpRequests
+                        .requestMatchers(GET, basePathPrefix + "/invitationCode").hasAuthority(INVITATION_CODE_READ)
+                        .requestMatchers(POST, basePathPrefix + "/invitationCode").hasAuthority(INVITATION_CODE_WRITE)
+                        .requestMatchers(DELETE, basePathPrefix + "/invitationCode/{invitationCodeId}").hasAuthority(INVITATION_CODE_WRITE);
+            } else {
+                authorizeHttpRequests.requestMatchers( basePathPrefix + "/invitationCode/**").denyAll();
+            }
 
-        urlRegistry.antMatchers("/actuator/**").permitAll();
+            authorizeHttpRequests
+                    .requestMatchers(basePathPrefix + "/hardware/**").authenticated()
+                    .requestMatchers(basePathPrefix + "/superadmin/**").hasAuthority(SUPERADMIN)
+                    .requestMatchers(basePathPrefix + "/**").authenticated();
+
+            authorizeHttpRequests.requestMatchers("/actuator/**").permitAll();
+
+            authorizeHttpRequests.anyRequest().authenticated();
+        });
 
         this.abstractApplicationSecurityJwtConfigurer.configure(http);
 
-        urlRegistry.anyRequest().authenticated();
         return http.build();
     }
 }

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/domain/dto/requests/RequestNewInvitationCodeParams.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/domain/dto/requests/RequestNewInvitationCodeParams.java
@@ -1,6 +1,6 @@
 package io.tech1.framework.b2b.base.security.jwt.domain.dto.requests;
 
-import javax.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotEmpty;
 import java.util.HashSet;
 import java.util.Set;
 

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/domain/dto/requests/RequestUserRegistration1.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/domain/dto/requests/RequestUserRegistration1.java
@@ -3,8 +3,8 @@ package io.tech1.framework.b2b.base.security.jwt.domain.dto.requests;
 import io.tech1.framework.domain.base.Password;
 import io.tech1.framework.domain.base.Username;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.time.ZoneId;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomString;

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/domain/dto/requests/RequestUserUpdate1.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/domain/dto/requests/RequestUserUpdate1.java
@@ -3,7 +3,7 @@ package io.tech1.framework.b2b.base.security.jwt.domain.dto.requests;
 import io.tech1.framework.domain.base.Email;
 import io.tech1.framework.domain.constants.ZoneIdsConstants;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.time.ZoneId;
 
 public record RequestUserUpdate1(

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/domain/dto/requests/RequestUserUpdate2.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/domain/dto/requests/RequestUserUpdate2.java
@@ -2,7 +2,7 @@ package io.tech1.framework.b2b.base.security.jwt.domain.dto.requests;
 
 import io.tech1.framework.domain.constants.ZoneIdsConstants;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.time.ZoneId;
 
 public record RequestUserUpdate2(

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/filters/jwt/JwtTokensFilter.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/filters/jwt/JwtTokensFilter.java
@@ -18,10 +18,10 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/filters/jwt_extension/DefaultJwtTokensFilterExtension.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/filters/jwt_extension/DefaultJwtTokensFilterExtension.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 @Slf4j
 @Component

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/filters/jwt_extension/JwtTokensFilterExtension.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/filters/jwt_extension/JwtTokensFilterExtension.java
@@ -3,7 +3,7 @@ package io.tech1.framework.b2b.base.security.jwt.filters.jwt_extension;
 import io.tech1.framework.domain.exceptions.tokens.*;
 import org.jetbrains.annotations.NotNull;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 public interface JwtTokensFilterExtension {
     void doFilter(@NotNull HttpServletRequest request) throws AccessTokenNotFoundException,

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/filters/logging/AdvancedRequestLoggingFilter.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/filters/logging/AdvancedRequestLoggingFilter.java
@@ -11,10 +11,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 import static java.nio.charset.Charset.defaultCharset;

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/handlers/exceptions/JwtAccessDeniedExceptionHandler.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/handlers/exceptions/JwtAccessDeniedExceptionHandler.java
@@ -9,8 +9,8 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @Slf4j

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/handlers/exceptions/JwtAuthenticationEntryPointExceptionHandler.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/handlers/exceptions/JwtAuthenticationEntryPointExceptionHandler.java
@@ -15,8 +15,8 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 import static io.tech1.framework.domain.utilities.http.HttpServletRequestUtility.getClientIpAddr;

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/resources/BaseSecurityAuthenticationResource.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/resources/BaseSecurityAuthenticationResource.java
@@ -22,9 +22,9 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.validation.Valid;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 
 import static io.tech1.framework.domain.enums.Status.COMPLETED;
 import static io.tech1.framework.domain.enums.Status.STARTED;

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/resources/BaseSecurityInvitationCodesResource.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/resources/BaseSecurityInvitationCodesResource.java
@@ -13,7 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
 @Slf4j

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/resources/BaseSecurityRegistrationResource.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/resources/BaseSecurityRegistrationResource.java
@@ -15,7 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
 @Slf4j

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/resources/BaseSecurityUsersResource.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/resources/BaseSecurityUsersResource.java
@@ -13,7 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
 @Slf4j

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/resources/BaseSecurityUsersSessionsResource.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/resources/BaseSecurityUsersSessionsResource.java
@@ -14,7 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
 @Slf4j

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/resources/BaseSuperAdminResource.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/resources/BaseSuperAdminResource.java
@@ -16,7 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 
 @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/services/BaseUsersSessionsService.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/services/BaseUsersSessionsService.java
@@ -12,7 +12,7 @@ import io.tech1.framework.b2b.base.security.jwt.domain.jwt.JwtUser;
 import io.tech1.framework.b2b.base.security.jwt.domain.sessions.SessionsExpiredTable;
 import io.tech1.framework.domain.base.Username;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Set;
 
 public interface BaseUsersSessionsService {

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/services/TokensService.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/services/TokensService.java
@@ -6,8 +6,8 @@ import io.tech1.framework.b2b.base.security.jwt.domain.jwt.RequestRefreshToken;
 import io.tech1.framework.b2b.base.security.jwt.domain.jwt.JwtUser;
 import io.tech1.framework.domain.exceptions.tokens.*;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public interface TokensService {
     JwtUser getJwtUserByAccessTokenOrThrow(

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/services/abstracts/AbstractBaseUsersSessionsService.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/services/abstracts/AbstractBaseUsersSessionsService.java
@@ -24,7 +24,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/services/impl/TokensServiceImpl.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/services/impl/TokensServiceImpl.java
@@ -17,8 +17,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
 @Slf4j

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/tests/random/BaseSecurityJwtRandomUtility.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/tests/random/BaseSecurityJwtRandomUtility.java
@@ -1,7 +1,7 @@
 package io.tech1.framework.b2b.base.security.jwt.tests.random;
 
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.impl.DefaultClaims;
+import io.jsonwebtoken.Jwts;
 import io.tech1.framework.domain.base.Username;
 import io.tech1.framework.domain.properties.base.TimeAmount;
 import lombok.experimental.UtilityClass;
@@ -20,25 +20,25 @@ import static java.time.ZoneOffset.UTC;
 public class BaseSecurityJwtRandomUtility {
 
     public static Claims validClaims() {
-        var claims = new DefaultClaims();
-        claims.setSubject(Username.testsHardcoded().value());
+        var claims = Jwts.claims();
+        claims.subject(Username.testsHardcoded().value());
         var timeAmount = new TimeAmount(1, ChronoUnit.HOURS);
         var expiration = convertLocalDateTime(LocalDateTime.now(UTC).plus(timeAmount.getAmount(), timeAmount.getUnit()), UTC);
-        claims.setIssuedAt(getIssuedAt());
-        claims.setExpiration(expiration);
-        claims.put("authorities", getSimpleGrantedAuthorities("admin", "user"));
-        return claims;
+        claims.issuedAt(getIssuedAt());
+        claims.expiration(expiration);
+        claims.add("authorities", getSimpleGrantedAuthorities("admin", "user"));
+        return claims.build();
     }
 
     public static Claims expiredClaims() {
-        var claims = new DefaultClaims();
-        claims.setSubject(Username.testsHardcoded().value());
+        var claims = Jwts.claims();
+        claims.subject(Username.testsHardcoded().value());
         var currentTimestamp = getCurrentTimestamp();
         var issuedAt = new Date(currentTimestamp);
         var expiration = new Date(currentTimestamp - 1000);
-        claims.setIssuedAt(issuedAt);
-        claims.setExpiration(expiration);
-        claims.put("authorities", getSimpleGrantedAuthorities("admin", "user"));
-        return claims;
+        claims.issuedAt(issuedAt);
+        claims.expiration(expiration);
+        claims.add("authorities", getSimpleGrantedAuthorities("admin", "user"));
+        return claims.build();
     }
 }

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/tokens/facade/TokensProvider.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/tokens/facade/TokensProvider.java
@@ -9,8 +9,8 @@ import io.tech1.framework.domain.exceptions.tokens.CsrfTokenNotFoundException;
 import io.tech1.framework.domain.exceptions.tokens.RefreshTokenNotFoundException;
 import org.springframework.security.web.csrf.DefaultCsrfToken;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public interface TokensProvider {
     void createResponseAccessToken(JwtAccessToken jwtAccessToken, HttpServletResponse response);

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/tokens/facade/impl/TokensProviderImpl.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/tokens/facade/impl/TokensProviderImpl.java
@@ -17,8 +17,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.web.csrf.DefaultCsrfToken;
 import org.springframework.stereotype.Service;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @Slf4j
 @Service

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/tokens/providers/TokenCookiesProvider.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/tokens/providers/TokenCookiesProvider.java
@@ -16,8 +16,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.web.csrf.DefaultCsrfToken;
 import org.springframework.stereotype.Service;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import static io.tech1.framework.domain.utilities.http.HttpCookieUtility.*;
 import static io.tech1.framework.domain.utilities.numbers.LongUtility.toIntExactOrZeroOnOverflow;

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/tokens/providers/TokenHeadersProvider.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/tokens/providers/TokenHeadersProvider.java
@@ -15,8 +15,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.web.csrf.DefaultCsrfToken;
 import org.springframework.stereotype.Service;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import static java.util.Objects.nonNull;
 

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/tokens/providers/TokenProvider.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/tokens/providers/TokenProvider.java
@@ -9,8 +9,8 @@ import io.tech1.framework.domain.exceptions.tokens.CsrfTokenNotFoundException;
 import io.tech1.framework.domain.exceptions.tokens.RefreshTokenNotFoundException;
 import org.springframework.security.web.csrf.DefaultCsrfToken;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public interface TokenProvider {
     void createResponseAccessToken(JwtAccessToken jwtAccessToken, HttpServletResponse response);

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/utils/HttpRequestUtils.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/utils/HttpRequestUtils.java
@@ -2,7 +2,7 @@ package io.tech1.framework.b2b.base.security.jwt.utils;
 
 import io.tech1.framework.domain.http.cache.CachedBodyHttpServletRequest;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 public interface HttpRequestUtils {
     boolean isCachedEndpoint(HttpServletRequest request);

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/utils/impl/HttpRequestUtilsImpl.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/utils/impl/HttpRequestUtilsImpl.java
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 @Slf4j
 @Component

--- a/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/utils/impl/SecurityJwtTokenUtilsImpl.java
+++ b/tech1-framework-b2b-base-security-jwt/src/main/java/io/tech1/framework/b2b/base/security/jwt/utils/impl/SecurityJwtTokenUtilsImpl.java
@@ -39,6 +39,8 @@ public class SecurityJwtTokenUtilsImpl implements SecurityJwtTokenUtils {
         this.applicationFrameworkProperties = applicationFrameworkProperties;
         var jwtTokensConfigs = this.applicationFrameworkProperties.getSecurityJwtConfigs().getJwtTokensConfigs();
         jwtTokensConfigs.assertProperties(new PropertyId("securityJwtConfigs.jwtTokensConfigs"));
+        // WARNING: consider using Base64 encoded key in properties, and decode it here
+        // https://www.baeldung.com/spring-security-sign-jwt-token#1-using-key-instance
         this.secretKey = Keys.hmacShaKeyFor(jwtTokensConfigs.getSecretKey().getBytes());
     }
 

--- a/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/assistants/current/base/BaseCurrentSessionAssistantTest.java
+++ b/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/assistants/current/base/BaseCurrentSessionAssistantTest.java
@@ -3,7 +3,6 @@ package io.tech1.framework.b2b.base.security.jwt.assistants.current.base;
 import io.tech1.framework.b2b.base.security.jwt.assistants.current.CurrentSessionAssistant;
 import io.tech1.framework.b2b.base.security.jwt.domain.db.UserSession;
 import io.tech1.framework.b2b.base.security.jwt.domain.dto.responses.ResponseUserSessionsTable;
-import io.tech1.framework.b2b.base.security.jwt.domain.identifiers.UserId;
 import io.tech1.framework.b2b.base.security.jwt.domain.jwt.JwtAccessToken;
 import io.tech1.framework.b2b.base.security.jwt.domain.jwt.JwtUser;
 import io.tech1.framework.b2b.base.security.jwt.domain.jwt.RequestAccessToken;
@@ -11,8 +10,6 @@ import io.tech1.framework.b2b.base.security.jwt.repositories.UsersSessionsReposi
 import io.tech1.framework.b2b.base.security.jwt.sessions.SessionRegistry;
 import io.tech1.framework.b2b.base.security.jwt.tokens.facade.TokensProvider;
 import io.tech1.framework.b2b.base.security.jwt.utils.SecurityPrincipalUtils;
-import io.tech1.framework.domain.base.Email;
-import io.tech1.framework.domain.base.Password;
 import io.tech1.framework.domain.base.Username;
 import io.tech1.framework.domain.exceptions.tokens.AccessTokenNotFoundException;
 import io.tech1.framework.domain.hardware.monitoring.HardwareMonitoringWidget;
@@ -32,14 +29,11 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
-import javax.servlet.http.HttpServletRequest;
-import java.util.HashMap;
-import java.util.HashSet;
+import jakarta.servlet.http.HttpServletRequest;
+
 import java.util.Set;
 
 import static io.tech1.framework.domain.utilities.random.EntityUtility.entity;
-import static io.tech1.framework.domain.utilities.random.RandomUtility.randomString;
-import static io.tech1.framework.domain.utilities.random.RandomUtility.randomZoneId;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 

--- a/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/filters/jwt/JwtTokensFilterTest.java
+++ b/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/filters/jwt/JwtTokensFilterTest.java
@@ -29,9 +29,9 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
-import javax.servlet.FilterChain;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.stream.Stream;
 
 import static io.tech1.framework.domain.utilities.random.EntityUtility.entity;

--- a/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/filters/logging/AdvancedRequestLoggingFilterTest.java
+++ b/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/filters/logging/AdvancedRequestLoggingFilterTest.java
@@ -19,10 +19,10 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 import static org.mockito.Mockito.*;

--- a/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/handlers/exceptions/JwtAccessDeniedExceptionHandlerTest.java
+++ b/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/handlers/exceptions/JwtAccessDeniedExceptionHandlerTest.java
@@ -15,8 +15,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.HashMap;

--- a/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/handlers/exceptions/JwtAuthenticationEntryPointExceptionHandlerTest.java
+++ b/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/handlers/exceptions/JwtAuthenticationEntryPointExceptionHandlerTest.java
@@ -24,8 +24,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.HashMap;

--- a/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/resources/BaseSecurityAuthenticationResourceTest.java
+++ b/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/resources/BaseSecurityAuthenticationResourceTest.java
@@ -33,9 +33,9 @@ import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.equalTo;

--- a/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/resources/BaseSecurityUsersSessionsResourceTest.java
+++ b/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/resources/BaseSecurityUsersSessionsResourceTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.time.ZoneId;
 
 import static io.tech1.framework.domain.utilities.random.EntityUtility.list345;

--- a/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/resources/BaseSuperAdminResourceTest.java
+++ b/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/resources/BaseSuperAdminResourceTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import static io.tech1.framework.domain.utilities.random.EntityUtility.entity;
 import static io.tech1.framework.domain.utilities.random.EntityUtility.list345;

--- a/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/services/abstracts/AbstractBaseUsersSessionsServiceTest.java
+++ b/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/services/abstracts/AbstractBaseUsersSessionsServiceTest.java
@@ -27,6 +27,7 @@ import io.tech1.framework.utilities.utils.UserMetadataUtils;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -392,6 +393,7 @@ class AbstractBaseUsersSessionsServiceTest {
         assertThat(userSessionAC.getValue().metadata()).isEqualTo(UserRequestMetadata.valid());
     }
 
+    @Disabled("Fix together with YYL")
     @Test
     void getExpiredSessionsTest() {
         // Arrange

--- a/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/services/abstracts/AbstractBaseUsersSessionsServiceTest.java
+++ b/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/services/abstracts/AbstractBaseUsersSessionsServiceTest.java
@@ -42,7 +42,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;

--- a/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/services/abstracts/AbstractBaseUsersSessionsServiceTest.java
+++ b/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/services/abstracts/AbstractBaseUsersSessionsServiceTest.java
@@ -24,10 +24,10 @@ import io.tech1.framework.domain.tuples.TupleToggle;
 import io.tech1.framework.properties.ApplicationFrameworkProperties;
 import io.tech1.framework.properties.tests.contexts.ApplicationFrameworkPropertiesContext;
 import io.tech1.framework.utilities.utils.UserMetadataUtils;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -43,7 +43,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -393,7 +392,6 @@ class AbstractBaseUsersSessionsServiceTest {
         assertThat(userSessionAC.getValue().metadata()).isEqualTo(UserRequestMetadata.valid());
     }
 
-    @Disabled("Fix together with YYL")
     @Test
     void getExpiredSessionsTest() {
         // Arrange
@@ -406,12 +404,12 @@ class AbstractBaseUsersSessionsServiceTest {
         var sessionExpiredUserSession = session(
                 Username.random(),
                 JwtAccessToken.random(),
-                new JwtRefreshToken("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJtdWx0aXVzZXI0MyIsImF1dGhvcml0aWVzIjpbeyJhdXRob3JpdHkiOiJhZG1pbiJ9LHsiYXV0aG9yaXR5IjoidXNlciJ9XSwiaWF0IjoxNjQyNzc0NTk3LCJleHAiOjE2NDI3NzQ2Mjd9.aCeKIy8uvei_c_aXoHlVhQ1N8wmjfguXgi2fWMRYVp8")
+                new JwtRefreshToken("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJtdWx0aXVzZXI0MyIsImF1dGhvcml0aWVzIjpbeyJhdXRob3JpdHkiOiJhZG1pbiJ9LHsiYXV0aG9yaXR5IjoidXNlciJ9XSwiaWF0IjoxNjQyNzc0NTk3LCJleHAiOjE2NDI3NzQ2Mjd9.KUkURlpCWsh0VJFC4xrCOxr_dXNusRRjdjFb88Wb4Rw")
         );
         var sessionAliveUserSession = session(
                 Username.random(),
                 JwtAccessToken.random(),
-                new JwtRefreshToken("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJtdWx0aXVzZXI0MyIsImF1dGhvcml0aWVzIjpbeyJhdXRob3JpdHkiOiJhZG1pbiJ9LHsiYXV0aG9yaXR5IjoidXNlciJ9XSwiaWF0IjoxNjQyNzc0Nzc4LCJleHAiOjQ3OTg0NDgzNzh9._BMUZR3wls5O1BYDm_4loYi3vn70GjE39Cpuqh-Z_bY")
+                new JwtRefreshToken("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJtdWx0aXVzZXI0MyIsImF1dGhvcml0aWVzIjpbeyJhdXRob3JpdHkiOiJhZG1pbiJ9LHsiYXV0aG9yaXR5IjoidXNlciJ9XSwiaWF0IjoxNjQyNzc0Nzc4LCJleHAiOjQ3OTg0NDgzNzh9.06Ep_ri727dkMEVA3zptDb8tmFn1VJ1FIhjjbE-mxpw")
         );
         var usersSessions = List.of(sessionInvalidUserSession, sessionExpiredUserSession, sessionAliveUserSession);
         when(this.usersSessionsRepository.findByUsernameInAsAny(usernames)).thenReturn(usersSessions);

--- a/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/services/impl/TokensServiceImplTest.java
+++ b/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/services/impl/TokensServiceImplTest.java
@@ -23,8 +23,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import static io.tech1.framework.b2b.base.security.jwt.domain.db.UserSession.randomPersistedSession;
 import static io.tech1.framework.b2b.base.security.jwt.tests.random.BaseSecurityJwtRandomUtility.validClaims;

--- a/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/tokens/facade/impl/TokensProviderImplTest.java
+++ b/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/tokens/facade/impl/TokensProviderImplTest.java
@@ -29,8 +29,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.stream.Stream;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomString;

--- a/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/tokens/providers/TokenCookiesProviderTest.java
+++ b/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/tokens/providers/TokenCookiesProviderTest.java
@@ -22,9 +22,9 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/tokens/providers/TokenHeadersProviderTest.java
+++ b/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/tokens/providers/TokenHeadersProviderTest.java
@@ -20,8 +20,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomString;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/utils/impl/HttpRequestUtilsImplTest.java
+++ b/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/utils/impl/HttpRequestUtilsImplTest.java
@@ -19,7 +19,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.stream.Stream;
 
 import static io.tech1.framework.b2b.base.security.jwt.utils.impl.HttpRequestUtilsImpl.CACHED_PAYLOAD_ATTRIBUTE;

--- a/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/utils/impl/SecurityJwtTokenUtilsImplTest.java
+++ b/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/utils/impl/SecurityJwtTokenUtilsImplTest.java
@@ -1,5 +1,6 @@
 package io.tech1.framework.b2b.base.security.jwt.utils.impl;
 
+import io.jsonwebtoken.Jwts;
 import io.tech1.framework.b2b.base.security.jwt.domain.jwt.JwtAccessToken;
 import io.tech1.framework.b2b.base.security.jwt.domain.jwt.JwtRefreshToken;
 import io.tech1.framework.b2b.base.security.jwt.domain.jwt.JwtTokenCreationParams;
@@ -10,6 +11,8 @@ import io.tech1.framework.domain.properties.base.TimeAmount;
 import io.tech1.framework.properties.ApplicationFrameworkProperties;
 import io.tech1.framework.properties.tests.contexts.ApplicationFrameworkPropertiesContext;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,6 +31,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Base64;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -41,6 +45,7 @@ import static java.util.Objects.nonNull;
 import static java.util.TimeZone.getTimeZone;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Slf4j
 @ExtendWith({ SpringExtension.class })
 @ContextConfiguration(loader= AnnotationConfigContextLoader.class)
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -129,6 +134,16 @@ class SecurityJwtTokenUtilsImplTest {
     private final ApplicationFrameworkProperties applicationFrameworkProperties;
 
     private final SecurityJwtTokenUtils componentUnderTest;
+
+    @Disabled("Only for debugging purposes")
+    @Test
+    void generateJwtSecretKey() {
+        // Act
+        var encodedSecretKey = Base64.getEncoder().encodeToString(Jwts.SIG.HS256.key().build().getEncoded());
+
+        // Assert
+        LOGGER.info("key: {}", encodedSecretKey);
+    }
 
     @Test
     void createJwtAccessTokenTest() {

--- a/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/utils/impl/SecurityJwtTokenUtilsImplTest.java
+++ b/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/utils/impl/SecurityJwtTokenUtilsImplTest.java
@@ -10,7 +10,6 @@ import io.tech1.framework.domain.properties.base.TimeAmount;
 import io.tech1.framework.properties.ApplicationFrameworkProperties;
 import io.tech1.framework.properties.tests.contexts.ApplicationFrameworkPropertiesContext;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -63,9 +62,9 @@ class SecurityJwtTokenUtilsImplTest {
 
     private static Stream<Arguments> validateTest() {
         return Stream.of(
-                Arguments.of("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbjIzIiwicm9sZXMiOlsiQURNSU4iLCJVU0VSIl0sImlhdCI6MTY0MTkyNDM4OSwiZXhwIjo3OTUzMjcxNTg5fQ.RUiEg-2yMDjl5b-TOMwpuXfOGq5zTQiosO9IoteMDAo", true),
-                Arguments.of("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIiLCJyb2xlcyI6WyJBRE1JTiIsIlVTRVIiXSwiaWF0IjoxNjQxOTI0NDA5LCJleHAiOjc5NTMyNzE2MDl9.p9gNAWxL-vi81zy7ECfqqDnjQ7GfvhyDMJyKJ4iBQys", true),
-                Arguments.of("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJtdWx0aXVzZXI0MyIsInJvbGVzIjpbIkFETUlOIiwiVVNFUiJdLCJpYXQiOjE2NDE5MzE4MjYsImV4cCI6MTY0MTkzMTgzNn0.EhKtfHCgOGrJEGR0G8czSHf1T6MywDYIKYpxlxV8GxI", true), // expired jwt token
+                Arguments.of("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbjIzIiwicm9sZXMiOlsiQURNSU4iLCJVU0VSIl0sImlhdCI6MTY0MTkyNDM4OSwiZXhwIjo3OTUzMjcxNTg5fQ.8vsV_RChHNOepRu452JlUTfS9qAo4K9qTROiop4WzUI", true),
+                Arguments.of("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIiLCJyb2xlcyI6WyJBRE1JTiIsIlVTRVIiXSwiaWF0IjoxNjQxOTI0NDA5LCJleHAiOjc5NTMyNzE2MDl9.QKi36h-8SuFDT-vr6PUN7_avwOsNK0d5uwSOP96G-VQ", true),
+                Arguments.of("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJtdWx0aXVzZXI0MyIsInJvbGVzIjpbIkFETUlOIiwiVVNFUiJdLCJpYXQiOjE2NDE5MzE4MjYsImV4cCI6MTY0MTkzMTgzNn0.xO49IBj2DKLvkUySWms1sK1B7IDzKH579nJgpbl2Mz0", true), // expired jwt token
                 Arguments.of("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIiLCJyb2xlcyI6WyJBRE1JTiIsIlVTRVIiXSwiaWF0IjoxNjQxOTI0NDA5LCJleHAiOjc5NTMyNzE2MDl9.p9gNAWxL-vi81zy7ECfqqDnjQ7GfvhyDMJyKJ4iBQyq1", false),
                 Arguments.of("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIiLCJyb2xlcyI6WyJBRE1JTiIsIlVTRVIiXSwiaWF0IjoxNjQxOTI0NDA5LCJleHAiOjc5NTMyNzE2MDl9.p9gNAWxL-vi81zy7ECfqqDnjQ7GfvhyDMJyKJ4iBQyq2", false)
         );
@@ -74,24 +73,24 @@ class SecurityJwtTokenUtilsImplTest {
     private static Stream<Arguments> isExpiredTest() {
         return Stream.of(
                 Arguments.of("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbjIzIiwicm9sZXMiOlsiQURNSU4iLCJVU0VSIl0sImlhdCI6MTY0MTkyNDM4OSwiZXhwIjo3OTUzMjcxNTg5fQ.RUiEg-2yMDjl5b-TOMwpuXfOGq5zTQiosO9IoteMDAo1", true),
-                Arguments.of("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbjIzIiwicm9sZXMiOlsiQURNSU4iLCJVU0VSIl0sImlhdCI6MTY0MTkyNDM4OSwiZXhwIjo3OTUzMjcxNTg5fQ.RUiEg-2yMDjl5b-TOMwpuXfOGq5zTQiosO9IoteMDAo", false),
-                Arguments.of("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIiLCJyb2xlcyI6WyJBRE1JTiIsIlVTRVIiXSwiaWF0IjoxNjQxOTI0NDA5LCJleHAiOjc5NTMyNzE2MDl9.p9gNAWxL-vi81zy7ECfqqDnjQ7GfvhyDMJyKJ4iBQys", false),
+                Arguments.of("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbjIzIiwicm9sZXMiOlsiQURNSU4iLCJVU0VSIl0sImlhdCI6MTY0MTkyNDM4OSwiZXhwIjo3OTUzMjcxNTg5fQ.8vsV_RChHNOepRu452JlUTfS9qAo4K9qTROiop4WzUI", false),
+                Arguments.of("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIiLCJyb2xlcyI6WyJBRE1JTiIsIlVTRVIiXSwiaWF0IjoxNjQxOTI0NDA5LCJleHAiOjc5NTMyNzE2MDl9.QKi36h-8SuFDT-vr6PUN7_avwOsNK0d5uwSOP96G-VQ", false),
                 Arguments.of("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJtdWx0aXVzZXI0MyIsInJvbGVzIjpbIkFETUlOIiwiVVNFUiJdLCJpYXQiOjE2NDE5MzE4MjYsImV4cCI6MTY0MTkzMTgzNn0.EhKtfHCgOGrJEGR0G8czSHf1T6MywDYIKYpxlxV8GxI", true)
         );
     }
 
     private static Stream<Arguments> getUsernameByClaimsTest() {
         return Stream.of(
-                Arguments.of("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbjIzIiwicm9sZXMiOlsiQURNSU4iLCJVU0VSIl0sImlhdCI6MTY0MTkyNDM4OSwiZXhwIjo3OTUzMjcxNTg5fQ.RUiEg-2yMDjl5b-TOMwpuXfOGq5zTQiosO9IoteMDAo", Username.of("admin23")),
-                Arguments.of("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIiLCJyb2xlcyI6WyJBRE1JTiIsIlVTRVIiXSwiaWF0IjoxNjQxOTI0NDA5LCJleHAiOjc5NTMyNzE2MDl9.p9gNAWxL-vi81zy7ECfqqDnjQ7GfvhyDMJyKJ4iBQys", Username.of("user12")),
-                Arguments.of("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJtdWx0aXVzZXI0MyIsInJvbGVzIjpbIkFETUlOIiwiVVNFUiJdLCJpYXQiOjE2NDE5MzE4MjYsImV4cCI6MTY0MTkzMTgzNn0.EhKtfHCgOGrJEGR0G8czSHf1T6MywDYIKYpxlxV8GxI", Username.of("multiuser43")) // expired jwt token
+                Arguments.of("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbjIzIiwicm9sZXMiOlsiQURNSU4iLCJVU0VSIl0sImlhdCI6MTY0MTkyNDM4OSwiZXhwIjo3OTUzMjcxNTg5fQ.8vsV_RChHNOepRu452JlUTfS9qAo4K9qTROiop4WzUI", Username.of("admin23")),
+                Arguments.of("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIiLCJyb2xlcyI6WyJBRE1JTiIsIlVTRVIiXSwiaWF0IjoxNjQxOTI0NDA5LCJleHAiOjc5NTMyNzE2MDl9.QKi36h-8SuFDT-vr6PUN7_avwOsNK0d5uwSOP96G-VQ", Username.of("user12")),
+                Arguments.of("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJtdWx0aXVzZXI0MyIsInJvbGVzIjpbIkFETUlOIiwiVVNFUiJdLCJpYXQiOjE2NDE5MzE4MjYsImV4cCI6MTY0MTkzMTgzNn0.xO49IBj2DKLvkUySWms1sK1B7IDzKH579nJgpbl2Mz0", Username.of("multiuser43")) // expired jwt token
         );
     }
 
     private static Stream<Arguments> versionsTests() {
         return Stream.of(
                 Arguments.of(
-                        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJtdWx0aXVzZXI0MyIsImF1dGhvcml0aWVzIjpbeyJhdXRob3JpdHkiOiJ1c2VyIn1dLCJpYXQiOjE2NDIyMDUyNzQsImV4cCI6NDc5Nzg3ODg3NH0.eJejXwTEj9Noemfdggw5hsbA6W0ID71zkb5wELB6LIU",
+                        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJtdWx0aXVzZXI0MyIsImF1dGhvcml0aWVzIjpbeyJhdXRob3JpdHkiOiJ1c2VyIn1dLCJpYXQiOjE2NDIyMDUyNzQsImV4cCI6NDc5Nzg3ODg3NH0.jQa_1ox0jj621g0256jlv4Ch9Ifrynjm1a76SFHvox8",
                         "15.01.2022 02:07:54",
                         "15.01.2122 02:07:54",
                         List.of(
@@ -99,7 +98,7 @@ class SecurityJwtTokenUtilsImplTest {
                         )
                 ),
                 Arguments.of(
-                        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJtdWx0aXVzZXI0MyIsImF1dGhvcml0aWVzIjpbeyJhdXRob3JpdHkiOiJhZG1pbiJ9LHsiYXV0aG9yaXR5IjoidXNlciJ9XSwiaWF0IjoxNjQyMjA1MTg4LCJleHAiOjQ3OTc4Nzg3ODh9.v8hqZe28EeZcODD84ycfl6JIUrPD6bgxFpxgn7PfLXk",
+                        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJtdWx0aXVzZXI0MyIsImF1dGhvcml0aWVzIjpbeyJhdXRob3JpdHkiOiJhZG1pbiJ9LHsiYXV0aG9yaXR5IjoidXNlciJ9XSwiaWF0IjoxNjQyMjA1MTg4LCJleHAiOjQ3OTc4Nzg3ODh9.pCkKoWBOT2u6bsr4iyESHmCEJaLBYZXU-unv1kqOtOc",
                         "15.01.2022 02:06:28",
                         "15.01.2122 02:06:28",
                         List.of(
@@ -195,7 +194,6 @@ class SecurityJwtTokenUtilsImplTest {
         assertThat(validatedClaims.expirationDate()).isBeforeOrEqualTo(expiration);
     }
 
-    @Disabled("Fix together with YYL")
     @ParameterizedTest
     @MethodSource("validateTest")
     void validateTest(String jwtToken, boolean expected) {
@@ -217,7 +215,6 @@ class SecurityJwtTokenUtilsImplTest {
         assertThat(refreshValidatedClaims.authorities()).isEmpty();
     }
 
-    @Disabled("Fix together with YYL")
     @ParameterizedTest
     @MethodSource("isExpiredTest")
     void isExpiredTest(String jwtToken, boolean expected) {
@@ -228,7 +225,6 @@ class SecurityJwtTokenUtilsImplTest {
         assertThat(validatedClaims.isExpired()).isEqualTo(expected);
     }
 
-    @Disabled("Fix together with YYL")
     @ParameterizedTest
     @MethodSource("getUsernameByClaimsTest")
     void getUsernameByClaimsTest(String jwtToken, Username expectedUsername) {
@@ -240,7 +236,6 @@ class SecurityJwtTokenUtilsImplTest {
         assertThat(validatedClaims.authorities()).isEmpty();
     }
 
-    @Disabled("Fix together with YYL")
     @ParameterizedTest
     @MethodSource("versionsTests")
     void getClaimsTest(String jwtToken, String expectedIssuedAt, String expectedExpiration, List<SimpleGrantedAuthority> authorities) throws ParseException {

--- a/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/utils/impl/SecurityJwtTokenUtilsImplTest.java
+++ b/tech1-framework-b2b-base-security-jwt/src/test/java/io/tech1/framework/b2b/base/security/jwt/utils/impl/SecurityJwtTokenUtilsImplTest.java
@@ -10,6 +10,7 @@ import io.tech1.framework.domain.properties.base.TimeAmount;
 import io.tech1.framework.properties.ApplicationFrameworkProperties;
 import io.tech1.framework.properties.tests.contexts.ApplicationFrameworkPropertiesContext;
 import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -194,6 +195,7 @@ class SecurityJwtTokenUtilsImplTest {
         assertThat(validatedClaims.expirationDate()).isBeforeOrEqualTo(expiration);
     }
 
+    @Disabled("Fix together with YYL")
     @ParameterizedTest
     @MethodSource("validateTest")
     void validateTest(String jwtToken, boolean expected) {
@@ -215,6 +217,7 @@ class SecurityJwtTokenUtilsImplTest {
         assertThat(refreshValidatedClaims.authorities()).isEmpty();
     }
 
+    @Disabled("Fix together with YYL")
     @ParameterizedTest
     @MethodSource("isExpiredTest")
     void isExpiredTest(String jwtToken, boolean expected) {
@@ -225,6 +228,7 @@ class SecurityJwtTokenUtilsImplTest {
         assertThat(validatedClaims.isExpired()).isEqualTo(expected);
     }
 
+    @Disabled("Fix together with YYL")
     @ParameterizedTest
     @MethodSource("getUsernameByClaimsTest")
     void getUsernameByClaimsTest(String jwtToken, Username expectedUsername) {
@@ -236,6 +240,7 @@ class SecurityJwtTokenUtilsImplTest {
         assertThat(validatedClaims.authorities()).isEmpty();
     }
 
+    @Disabled("Fix together with YYL")
     @ParameterizedTest
     @MethodSource("versionsTests")
     void getClaimsTest(String jwtToken, String expectedIssuedAt, String expectedExpiration, List<SimpleGrantedAuthority> authorities) throws ParseException {

--- a/tech1-framework-b2b-mongodb-security-jwt/src/main/java/io/tech1/framework/b2b/mongodb/security/jwt/configurations/ApplicationMongo.java
+++ b/tech1-framework-b2b-mongodb-security-jwt/src/main/java/io/tech1/framework/b2b/mongodb/security/jwt/configurations/ApplicationMongo.java
@@ -20,7 +20,7 @@ import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 @Configuration
 @Import({

--- a/tech1-framework-b2b-mongodb-server/src/main/java/io/tech1/framework/b2b/mongodb/server/configurations/ApplicationTech1.java
+++ b/tech1-framework-b2b-mongodb-server/src/main/java/io/tech1/framework/b2b/mongodb/server/configurations/ApplicationTech1.java
@@ -57,7 +57,6 @@ public class ApplicationTech1 implements AbstractApplicationSecurityJwtConfigure
         http.authorizeHttpRequests(authorizeHttpRequests ->
                 authorizeHttpRequests
                         .requestMatchers("/hardware/**").permitAll()
-                        .anyRequest().authenticated()
         );
     }
 

--- a/tech1-framework-b2b-mongodb-server/src/main/java/io/tech1/framework/b2b/mongodb/server/configurations/ApplicationTech1.java
+++ b/tech1-framework-b2b-mongodb-server/src/main/java/io/tech1/framework/b2b/mongodb/server/configurations/ApplicationTech1.java
@@ -52,11 +52,12 @@ public class ApplicationTech1 implements AbstractApplicationSecurityJwtConfigure
         // no tech1-server configurations yet
     }
 
-    // TODO [VB] deprecated
     @Override
     public void configure(HttpSecurity http) throws Exception {
-        var urlRegistry = http.authorizeRequests();
-        urlRegistry.antMatchers("/hardware/**").permitAll();
+        http.authorizeHttpRequests(authorizeHttpRequests ->
+                authorizeHttpRequests
+                        .requestMatchers("/hardware/**").permitAll()
+        );
     }
 
     @Bean

--- a/tech1-framework-b2b-mongodb-server/src/main/java/io/tech1/framework/b2b/mongodb/server/configurations/ApplicationTech1.java
+++ b/tech1-framework-b2b-mongodb-server/src/main/java/io/tech1/framework/b2b/mongodb/server/configurations/ApplicationTech1.java
@@ -57,6 +57,7 @@ public class ApplicationTech1 implements AbstractApplicationSecurityJwtConfigure
         http.authorizeHttpRequests(authorizeHttpRequests ->
                 authorizeHttpRequests
                         .requestMatchers("/hardware/**").permitAll()
+                        .anyRequest().authenticated()
         );
     }
 

--- a/tech1-framework-b2b-mongodb-server/src/main/java/io/tech1/framework/b2b/mongodb/server/configurations/ApplicationTech1.java
+++ b/tech1-framework-b2b-mongodb-server/src/main/java/io/tech1/framework/b2b/mongodb/server/configurations/ApplicationTech1.java
@@ -9,6 +9,7 @@ import io.tech1.framework.hardware.configurations.ApplicationHardwareMonitoring;
 import io.tech1.framework.hardware.monitoring.store.HardwareMonitoringStore;
 import io.tech1.framework.hardware.monitoring.subscribers.HardwareMonitoringSubscriber;
 import io.tech1.framework.hardware.monitoring.subscribers.impl.BaseHardwareMonitoringSubscriber;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -17,8 +18,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
-
-import javax.annotation.PostConstruct;
 
 @Configuration
 @ComponentScan({
@@ -53,6 +52,7 @@ public class ApplicationTech1 implements AbstractApplicationSecurityJwtConfigure
         // no tech1-server configurations yet
     }
 
+    // TODO [VB] deprecated
     @Override
     public void configure(HttpSecurity http) throws Exception {
         var urlRegistry = http.authorizeRequests();

--- a/tech1-framework-b2b-mongodb-server/src/main/java/io/tech1/framework/b2b/mongodb/server/properties/server/ServerConfigs.java
+++ b/tech1-framework-b2b-mongodb-server/src/main/java/io/tech1/framework/b2b/mongodb/server/properties/server/ServerConfigs.java
@@ -6,7 +6,7 @@ import io.tech1.framework.domain.properties.base.AbstractPropertyConfigs;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 // Lombok (property-based)
 @AllArgsConstructor(onConstructor = @__({@ConstructorBinding}))

--- a/tech1-framework-b2b-postgres-security-jwt/pom.xml
+++ b/tech1-framework-b2b-postgres-security-jwt/pom.xml
@@ -33,8 +33,8 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>com.vladmihalcea</groupId>
-            <artifactId>hibernate-types-52</artifactId>
+            <groupId>io.hypersistence</groupId>
+            <artifactId>hypersistence-utils-hibernate-63</artifactId>
         </dependency>
         <!-- Liquibase -->
         <dependency>

--- a/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/AbstractAttributeConverter.java
+++ b/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/AbstractAttributeConverter.java
@@ -2,7 +2,7 @@ package io.tech1.framework.b2b.postgres.security.jwt.converters.columns;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import javax.persistence.AttributeConverter;
+import jakarta.persistence.AttributeConverter;
 
 public abstract class AbstractAttributeConverter<X, Y> implements AttributeConverter<X, Y> {
     protected final ObjectMapper objectMapper = new ObjectMapper();

--- a/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/PostgresEmailConverter.java
+++ b/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/PostgresEmailConverter.java
@@ -2,8 +2,8 @@ package io.tech1.framework.b2b.postgres.security.jwt.converters.columns;
 
 import io.tech1.framework.domain.base.Email;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 
 import static java.util.Objects.nonNull;
 

--- a/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/PostgresJwtAccessTokenConverter.java
+++ b/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/PostgresJwtAccessTokenConverter.java
@@ -2,8 +2,8 @@ package io.tech1.framework.b2b.postgres.security.jwt.converters.columns;
 
 import io.tech1.framework.b2b.base.security.jwt.domain.jwt.JwtAccessToken;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 
 import static java.util.Objects.nonNull;
 

--- a/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/PostgresJwtRefreshTokenConverter.java
+++ b/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/PostgresJwtRefreshTokenConverter.java
@@ -2,8 +2,8 @@ package io.tech1.framework.b2b.postgres.security.jwt.converters.columns;
 
 import io.tech1.framework.b2b.base.security.jwt.domain.jwt.JwtRefreshToken;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 
 import static java.util.Objects.nonNull;
 

--- a/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/PostgresMapStringsObjectsConverter.java
+++ b/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/PostgresMapStringsObjectsConverter.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 import java.util.Map;
 
 @Converter

--- a/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/PostgresPasswordConverter.java
+++ b/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/PostgresPasswordConverter.java
@@ -2,8 +2,8 @@ package io.tech1.framework.b2b.postgres.security.jwt.converters.columns;
 
 import io.tech1.framework.domain.base.Password;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 
 @Converter
 public class PostgresPasswordConverter implements AttributeConverter<Password, String> {

--- a/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/PostgresSetOfSimpleGrantedAuthoritiesConverter.java
+++ b/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/PostgresSetOfSimpleGrantedAuthoritiesConverter.java
@@ -2,8 +2,8 @@ package io.tech1.framework.b2b.postgres.security.jwt.converters.columns;
 
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;

--- a/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/PostgresUserRequestMetadataConverter.java
+++ b/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/PostgresUserRequestMetadataConverter.java
@@ -7,7 +7,7 @@ import io.tech1.framework.domain.http.requests.UserAgentDetails;
 import io.tech1.framework.domain.http.requests.UserRequestMetadata;
 import lombok.SneakyThrows;
 
-import javax.persistence.Converter;
+import jakarta.persistence.Converter;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/PostgresUsernameConverter.java
+++ b/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/PostgresUsernameConverter.java
@@ -2,8 +2,8 @@ package io.tech1.framework.b2b.postgres.security.jwt.converters.columns;
 
 import io.tech1.framework.domain.base.Username;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 
 import static java.util.Objects.nonNull;
 

--- a/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/PostgresVersionConverter.java
+++ b/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/PostgresVersionConverter.java
@@ -2,9 +2,10 @@ package io.tech1.framework.b2b.postgres.security.jwt.converters.columns;
 
 import io.tech1.framework.domain.base.Version;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 
+// TODO [YYL] never used
 @Converter
 public class PostgresVersionConverter implements AttributeConverter<Version, String> {
 

--- a/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/PostgresVersionConverter.java
+++ b/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/PostgresVersionConverter.java
@@ -5,7 +5,6 @@ import io.tech1.framework.domain.base.Version;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 
-// TODO [YYL] never used
 @Converter
 public class PostgresVersionConverter implements AttributeConverter<Version, String> {
 

--- a/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/PostgresZoneIdConverter.java
+++ b/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/converters/columns/PostgresZoneIdConverter.java
@@ -1,7 +1,7 @@
 package io.tech1.framework.b2b.postgres.security.jwt.converters.columns;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 import java.time.ZoneId;
 
 import static java.util.Objects.nonNull;

--- a/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/domain/db/PostgresDbInvitationCode.java
+++ b/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/domain/db/PostgresDbInvitationCode.java
@@ -11,7 +11,7 @@ import io.tech1.framework.domain.base.Username;
 import lombok.*;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.Set;
 
 import static io.tech1.framework.b2b.base.security.jwt.utilities.SpringAuthoritiesUtility.getResponseInvitationCodeAuthoritiesAsField;

--- a/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/domain/db/PostgresDbUser.java
+++ b/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/domain/db/PostgresDbUser.java
@@ -11,7 +11,7 @@ import io.tech1.framework.domain.base.Username;
 import lombok.*;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Map;

--- a/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/domain/db/PostgresDbUserSession.java
+++ b/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/domain/db/PostgresDbUserSession.java
@@ -16,7 +16,7 @@ import io.tech1.framework.domain.base.Username;
 import io.tech1.framework.domain.http.requests.UserRequestMetadata;
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import static io.tech1.framework.b2b.base.security.jwt.domain.db.UserSession.ofNotPersisted;
 import static io.tech1.framework.b2b.base.security.jwt.domain.db.UserSession.ofPersisted;

--- a/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/domain/superclasses/PostgresDbAbstractPersistable0.java
+++ b/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/domain/superclasses/PostgresDbAbstractPersistable0.java
@@ -4,12 +4,13 @@ import org.hibernate.annotations.GenericGenerator;
 import org.springframework.data.domain.Persistable;
 import org.springframework.lang.Nullable;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import static java.util.Objects.isNull;
 
 @MappedSuperclass
 public abstract class PostgresDbAbstractPersistable0 implements Persistable<String> {
+    // TODO [VB] deprecated
     @Id
     @GenericGenerator(name = "uuid2", strategy = "uuid2")
     @GeneratedValue(strategy = GenerationType.IDENTITY, generator = "uuid2")

--- a/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/domain/superclasses/PostgresDbAbstractPersistable0.java
+++ b/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/domain/superclasses/PostgresDbAbstractPersistable0.java
@@ -1,18 +1,17 @@
 package io.tech1.framework.b2b.postgres.security.jwt.domain.superclasses;
 
+import jakarta.persistence.*;
 import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.id.uuid.UuidGenerator;
 import org.springframework.data.domain.Persistable;
 import org.springframework.lang.Nullable;
-
-import jakarta.persistence.*;
 
 import static java.util.Objects.isNull;
 
 @MappedSuperclass
 public abstract class PostgresDbAbstractPersistable0 implements Persistable<String> {
-    // TODO [VB] deprecated
     @Id
-    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @GenericGenerator(name = "uuid2", type = UuidGenerator.class)
     @GeneratedValue(strategy = GenerationType.IDENTITY, generator = "uuid2")
     @Column(length = 36, nullable = false, updatable = false)
     protected String id;

--- a/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/domain/superclasses/PostgresDbAbstractPersistable0.java
+++ b/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/domain/superclasses/PostgresDbAbstractPersistable0.java
@@ -1,8 +1,6 @@
 package io.tech1.framework.b2b.postgres.security.jwt.domain.superclasses;
 
 import jakarta.persistence.*;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.id.uuid.UuidGenerator;
 import org.springframework.data.domain.Persistable;
 import org.springframework.lang.Nullable;
 
@@ -11,8 +9,7 @@ import static java.util.Objects.isNull;
 @MappedSuperclass
 public abstract class PostgresDbAbstractPersistable0 implements Persistable<String> {
     @Id
-    @GenericGenerator(name = "uuid2", type = UuidGenerator.class)
-    @GeneratedValue(strategy = GenerationType.IDENTITY, generator = "uuid2")
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(length = 36, nullable = false, updatable = false)
     protected String id;
 

--- a/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/domain/superclasses/PostgresDbAbstractPersistable1.java
+++ b/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/domain/superclasses/PostgresDbAbstractPersistable1.java
@@ -3,8 +3,8 @@ package io.tech1.framework.b2b.postgres.security.jwt.domain.superclasses;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.persistence.Column;
-import javax.persistence.MappedSuperclass;
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
 
 import static io.tech1.framework.domain.utilities.time.TimestampUtility.getCurrentTimestamp;
 

--- a/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/domain/superclasses/PostgresDbAbstractPersistable2.java
+++ b/tech1-framework-b2b-postgres-security-jwt/src/main/java/io/tech1/framework/b2b/postgres/security/jwt/domain/superclasses/PostgresDbAbstractPersistable2.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import static io.tech1.framework.domain.utilities.time.TimestampUtility.getCurrentTimestamp;
 

--- a/tech1-framework-b2b-postgres-server/src/main/java/io/tech1/framework/b2b/postgres/server/configurations/ApplicationTech1.java
+++ b/tech1-framework-b2b-postgres-server/src/main/java/io/tech1/framework/b2b/postgres/server/configurations/ApplicationTech1.java
@@ -61,11 +61,12 @@ public class ApplicationTech1 implements AbstractApplicationSecurityJwtConfigure
         // no tech1-server configurations yet
     }
 
-    // TODO [VB] deprecated
     @Override
     public void configure(HttpSecurity http) throws Exception {
-        var urlRegistry = http.authorizeRequests();
-        urlRegistry.antMatchers("/hardware/**").permitAll();
+        http.authorizeHttpRequests(authorizeHttpRequests ->
+                authorizeHttpRequests
+                        .requestMatchers("/hardware/**").permitAll()
+        );
     }
 
     @Bean

--- a/tech1-framework-b2b-postgres-server/src/main/java/io/tech1/framework/b2b/postgres/server/configurations/ApplicationTech1.java
+++ b/tech1-framework-b2b-postgres-server/src/main/java/io/tech1/framework/b2b/postgres/server/configurations/ApplicationTech1.java
@@ -20,7 +20,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 @Configuration
 @ComponentScan({
@@ -61,6 +61,7 @@ public class ApplicationTech1 implements AbstractApplicationSecurityJwtConfigure
         // no tech1-server configurations yet
     }
 
+    // TODO [VB] deprecated
     @Override
     public void configure(HttpSecurity http) throws Exception {
         var urlRegistry = http.authorizeRequests();

--- a/tech1-framework-b2b-postgres-server/src/main/java/io/tech1/framework/b2b/postgres/server/configurations/ApplicationTech1.java
+++ b/tech1-framework-b2b-postgres-server/src/main/java/io/tech1/framework/b2b/postgres/server/configurations/ApplicationTech1.java
@@ -66,7 +66,6 @@ public class ApplicationTech1 implements AbstractApplicationSecurityJwtConfigure
         http.authorizeHttpRequests(authorizeHttpRequests ->
                 authorizeHttpRequests
                         .requestMatchers("/hardware/**").permitAll()
-                        .anyRequest().authenticated()
         );
     }
 

--- a/tech1-framework-b2b-postgres-server/src/main/java/io/tech1/framework/b2b/postgres/server/configurations/ApplicationTech1.java
+++ b/tech1-framework-b2b-postgres-server/src/main/java/io/tech1/framework/b2b/postgres/server/configurations/ApplicationTech1.java
@@ -66,6 +66,7 @@ public class ApplicationTech1 implements AbstractApplicationSecurityJwtConfigure
         http.authorizeHttpRequests(authorizeHttpRequests ->
                 authorizeHttpRequests
                         .requestMatchers("/hardware/**").permitAll()
+                        .anyRequest().authenticated()
         );
     }
 

--- a/tech1-framework-b2b-postgres-server/src/main/java/io/tech1/framework/b2b/postgres/server/domain/db/PostgresDbAnything.java
+++ b/tech1-framework-b2b-postgres-server/src/main/java/io/tech1/framework/b2b/postgres/server/domain/db/PostgresDbAnything.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.hibernate.annotations.GenericGenerator;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import static io.tech1.framework.b2b.postgres.server.constants.TablesConstants.ANYTHING;
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomStringLetterOrNumbersOnly;
@@ -22,6 +22,7 @@ import static io.tech1.framework.domain.utilities.random.RandomUtility.randomStr
 @Entity
 @Table(name = ANYTHING)
 public class PostgresDbAnything {
+    // TODO [VB] deprecated
     @Id
     @GenericGenerator(name = "uuid2", strategy = "uuid2")
     @GeneratedValue(strategy = GenerationType.IDENTITY, generator = "uuid2")

--- a/tech1-framework-b2b-postgres-server/src/main/java/io/tech1/framework/b2b/postgres/server/domain/db/PostgresDbAnything.java
+++ b/tech1-framework-b2b-postgres-server/src/main/java/io/tech1/framework/b2b/postgres/server/domain/db/PostgresDbAnything.java
@@ -2,14 +2,11 @@ package io.tech1.framework.b2b.postgres.server.domain.db;
 
 import io.tech1.framework.b2b.postgres.security.jwt.converters.columns.PostgresUsernameConverter;
 import io.tech1.framework.domain.base.Username;
+import jakarta.persistence.*;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.hibernate.annotations.GenericGenerator;
-
-import jakarta.persistence.*;
-import org.hibernate.id.uuid.UuidGenerator;
 
 import static io.tech1.framework.b2b.postgres.server.constants.TablesConstants.ANYTHING;
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomStringLetterOrNumbersOnly;
@@ -24,8 +21,7 @@ import static io.tech1.framework.domain.utilities.random.RandomUtility.randomStr
 @Table(name = ANYTHING)
 public class PostgresDbAnything {
     @Id
-    @GenericGenerator(name = "uuid2", type = UuidGenerator.class)
-    @GeneratedValue(strategy = GenerationType.IDENTITY, generator = "uuid2")
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(length = 36, nullable = false, updatable = false)
     private String id;
 

--- a/tech1-framework-b2b-postgres-server/src/main/java/io/tech1/framework/b2b/postgres/server/domain/db/PostgresDbAnything.java
+++ b/tech1-framework-b2b-postgres-server/src/main/java/io/tech1/framework/b2b/postgres/server/domain/db/PostgresDbAnything.java
@@ -9,6 +9,7 @@ import lombok.ToString;
 import org.hibernate.annotations.GenericGenerator;
 
 import jakarta.persistence.*;
+import org.hibernate.id.uuid.UuidGenerator;
 
 import static io.tech1.framework.b2b.postgres.server.constants.TablesConstants.ANYTHING;
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomStringLetterOrNumbersOnly;
@@ -22,9 +23,8 @@ import static io.tech1.framework.domain.utilities.random.RandomUtility.randomStr
 @Entity
 @Table(name = ANYTHING)
 public class PostgresDbAnything {
-    // TODO [VB] deprecated
     @Id
-    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @GenericGenerator(name = "uuid2", type = UuidGenerator.class)
     @GeneratedValue(strategy = GenerationType.IDENTITY, generator = "uuid2")
     @Column(length = 36, nullable = false, updatable = false)
     private String id;

--- a/tech1-framework-b2b-postgres-server/src/main/java/io/tech1/framework/b2b/postgres/server/properties/server/ServerConfigs.java
+++ b/tech1-framework-b2b-postgres-server/src/main/java/io/tech1/framework/b2b/postgres/server/properties/server/ServerConfigs.java
@@ -6,7 +6,7 @@ import io.tech1.framework.domain.properties.base.AbstractPropertyConfigs;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 // Lombok (property-based)
 @AllArgsConstructor(onConstructor = @__({@ConstructorBinding}))

--- a/tech1-framework-configurations/src/main/java/io/tech1/framework/configurations/async/ApplicationAsync.java
+++ b/tech1-framework-configurations/src/main/java/io/tech1/framework/configurations/async/ApplicationAsync.java
@@ -12,7 +12,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.util.concurrent.Executor;
 
 import static io.tech1.framework.domain.utilities.processors.ProcessorsUtility.getHalfOfCores;

--- a/tech1-framework-configurations/src/main/java/io/tech1/framework/configurations/events/ApplicationEvents.java
+++ b/tech1-framework-configurations/src/main/java/io/tech1/framework/configurations/events/ApplicationEvents.java
@@ -2,6 +2,7 @@ package io.tech1.framework.configurations.events;
 
 import io.tech1.framework.domain.base.PropertyId;
 import io.tech1.framework.properties.ApplicationFrameworkProperties;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -10,8 +11,6 @@ import org.springframework.context.event.ApplicationEventMulticaster;
 import org.springframework.context.event.SimpleApplicationEventMulticaster;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.support.TaskUtils;
-
-import javax.annotation.PostConstruct;
 
 import static io.tech1.framework.domain.utilities.processors.ProcessorsUtility.getHalfOfCores;
 import static io.tech1.framework.domain.utilities.processors.ProcessorsUtility.getNumOfCores;

--- a/tech1-framework-configurations/src/main/java/io/tech1/framework/configurations/mvc/ApplicationMVC.java
+++ b/tech1-framework-configurations/src/main/java/io/tech1/framework/configurations/mvc/ApplicationMVC.java
@@ -10,7 +10,7 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import static java.util.Objects.nonNull;
 

--- a/tech1-framework-configurations/src/main/java/io/tech1/framework/configurations/server/ApplicationSpringBootServer.java
+++ b/tech1-framework-configurations/src/main/java/io/tech1/framework/configurations/server/ApplicationSpringBootServer.java
@@ -5,13 +5,12 @@ import io.tech1.framework.properties.ApplicationFrameworkProperties;
 import io.tech1.framework.utilities.environment.EnvironmentUtility;
 import io.tech1.framework.utilities.environment.base.BaseEnvironmentUtility;
 import io.tech1.framework.utilities.resources.actuator.BaseInfoResource;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
-
-import javax.annotation.PostConstruct;
 
 @Configuration
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))

--- a/tech1-framework-domain/pom.xml
+++ b/tech1-framework-domain/pom.xml
@@ -56,11 +56,6 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>
-        <!-- Tomcat: Cookie, CacheHttpRequests -->
-        <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-core</artifactId>
-        </dependency>
         <!-- JColor (console asserts) -->
         <dependency>
             <groupId>com.diogonunes</groupId>

--- a/tech1-framework-domain/pom.xml
+++ b/tech1-framework-domain/pom.xml
@@ -32,11 +32,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-        <!-- j8 -> j11 migration, @ObjectMapper related, API, javax.xml.bind module -->
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-        </dependency>
         <!-- JSONs: Jackson -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/base/Email.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/base/Email.java
@@ -5,10 +5,10 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.tech1.framework.domain.constants.DomainConstants;
 import org.jetbrains.annotations.NotNull;
 
-import javax.validation.Constraint;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/base/Password.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/base/Password.java
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import org.jetbrains.annotations.NotNull;
 
-import javax.validation.Constraint;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/base/ServerName.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/base/ServerName.java
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import org.jetbrains.annotations.NotNull;
 
-import javax.validation.Constraint;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/base/Timestamp.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/base/Timestamp.java
@@ -3,10 +3,10 @@ package io.tech1.framework.domain.base;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import javax.validation.Constraint;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/base/Username.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/base/Username.java
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import org.jetbrains.annotations.NotNull;
 
-import javax.validation.Constraint;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/base/Version.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/base/Version.java
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import org.jetbrains.annotations.NotNull;
 
-import javax.validation.Constraint;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/exceptions/ExceptionEntity.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/exceptions/ExceptionEntity.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import lombok.ToString;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/http/cache/CachedBodyHttpServletRequest.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/http/cache/CachedBodyHttpServletRequest.java
@@ -2,9 +2,9 @@ package io.tech1.framework.domain.http.cache;
 
 import org.springframework.util.StreamUtils;
 
-import javax.servlet.ServletInputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/http/cache/CachedBodyServletInputStream.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/http/cache/CachedBodyServletInputStream.java
@@ -1,7 +1,7 @@
 package io.tech1.framework.domain.http.cache;
 
-import javax.servlet.ReadListener;
-import javax.servlet.ServletInputStream;
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/http/requests/UserAgentHeader.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/http/requests/UserAgentHeader.java
@@ -5,7 +5,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import static java.util.Objects.isNull;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/Authority.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/Authority.java
@@ -4,7 +4,7 @@ import io.tech1.framework.domain.properties.annotations.MandatoryProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomString;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/Checkbox.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/Checkbox.java
@@ -4,7 +4,7 @@ import io.tech1.framework.domain.properties.annotations.MandatoryProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomBoolean;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/Cron.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/Cron.java
@@ -7,7 +7,7 @@ import io.tech1.framework.domain.properties.annotations.NonMandatoryProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomBoolean;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/DefaultUser.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/DefaultUser.java
@@ -10,7 +10,7 @@ import io.tech1.framework.domain.utilities.random.RandomUtility;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import java.time.ZoneId;
 import java.util.Set;

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/DefaultUsers.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/DefaultUsers.java
@@ -7,7 +7,7 @@ import io.tech1.framework.domain.properties.annotations.MandatoryToggleProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import java.time.ZoneId;
 import java.util.*;

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/InvitationCodes.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/InvitationCodes.java
@@ -4,7 +4,7 @@ import io.tech1.framework.domain.properties.annotations.MandatoryProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomBoolean;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/JwtToken.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/JwtToken.java
@@ -7,7 +7,7 @@ import io.tech1.framework.domain.properties.annotations.NonMandatoryProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.asserts.Asserts.assertFalseOrThrow;
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomBoolean;

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/Mongodb.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/Mongodb.java
@@ -7,7 +7,7 @@ import io.tech1.framework.domain.properties.annotations.NonMandatoryProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.*;
 import static java.util.Objects.nonNull;

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/RemoteServer.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/RemoteServer.java
@@ -6,7 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomIPv4;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/ScheduledJob.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/ScheduledJob.java
@@ -5,7 +5,7 @@ import io.tech1.framework.domain.properties.annotations.MandatoryToggleProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomBoolean;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/SchedulerConfiguration.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/SchedulerConfiguration.java
@@ -4,7 +4,7 @@ import io.tech1.framework.domain.properties.annotations.MandatoryProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import java.util.concurrent.TimeUnit;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/SpringLogging.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/SpringLogging.java
@@ -4,7 +4,7 @@ import io.tech1.framework.domain.properties.annotations.MandatoryProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomString;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/SpringServer.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/SpringServer.java
@@ -5,7 +5,7 @@ import io.tech1.framework.domain.utilities.random.RandomUtility;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 // Lombok (property-based)
 @AllArgsConstructor(onConstructor = @__({@ConstructorBinding}))

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/TimeAmount.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/base/TimeAmount.java
@@ -4,7 +4,7 @@ import io.tech1.framework.domain.properties.annotations.MandatoryProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import java.time.temporal.ChronoUnit;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/AsyncConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/AsyncConfigs.java
@@ -4,7 +4,7 @@ import io.tech1.framework.domain.properties.annotations.MandatoryProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomString;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/EmailConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/EmailConfigs.java
@@ -7,7 +7,7 @@ import io.tech1.framework.domain.properties.annotations.MandatoryToggleProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 // Lombok (property-based)
 @AllArgsConstructor(onConstructor = @__({@ConstructorBinding}))

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/EventsConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/EventsConfigs.java
@@ -4,7 +4,7 @@ import io.tech1.framework.domain.properties.annotations.MandatoryProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomString;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/HardwareMonitoringConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/HardwareMonitoringConfigs.java
@@ -7,7 +7,7 @@ import io.tech1.framework.domain.properties.annotations.MandatoryToggleProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import java.math.BigDecimal;
 import java.util.EnumMap;

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/HardwareServerConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/HardwareServerConfigs.java
@@ -4,7 +4,7 @@ import io.tech1.framework.domain.properties.annotations.MandatoryProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomIPv4;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/IncidentConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/IncidentConfigs.java
@@ -6,7 +6,7 @@ import io.tech1.framework.domain.properties.base.RemoteServer;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomBoolean;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/MavenConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/MavenConfigs.java
@@ -6,7 +6,7 @@ import io.tech1.framework.domain.properties.annotations.MandatoryProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 // Lombok (property-based)
 @AllArgsConstructor(onConstructor = @__({@ConstructorBinding}))

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/MongodbSecurityJwtConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/MongodbSecurityJwtConfigs.java
@@ -5,7 +5,7 @@ import io.tech1.framework.domain.properties.base.Mongodb;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 // Lombok (property-based)
 @AllArgsConstructor(onConstructor = @__({@ConstructorBinding}))

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/MvcConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/MvcConfigs.java
@@ -6,7 +6,7 @@ import io.tech1.framework.domain.properties.configs.mvc.CorsConfigs;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomBoolean;
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomString;

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/SecurityJwtConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/SecurityJwtConfigs.java
@@ -10,7 +10,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.SimpleBeanDefinitionRegistry;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 import org.springframework.context.annotation.ClassPathBeanDefinitionScanner;
 import org.springframework.core.type.filter.AssignableTypeFilter;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/SecurityJwtWebsocketsConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/SecurityJwtWebsocketsConfigs.java
@@ -6,7 +6,7 @@ import io.tech1.framework.domain.properties.configs.security.jwt.websockets.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 // Lombok (property-based)
 @AllArgsConstructor(onConstructor = @__({@ConstructorBinding}))

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/ServerConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/ServerConfigs.java
@@ -6,7 +6,7 @@ import io.tech1.framework.domain.properties.annotations.NonMandatoryProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomString;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/UtilitiesConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/UtilitiesConfigs.java
@@ -7,7 +7,7 @@ import io.tech1.framework.domain.properties.configs.utilities.UserAgentConfigs;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 // Lombok (property-based)
 @AllArgsConstructor(onConstructor = @__({@ConstructorBinding}))

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/mvc/CorsConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/mvc/CorsConfigs.java
@@ -6,7 +6,7 @@ import io.tech1.framework.domain.utilities.random.RandomUtility;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import java.util.Set;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/AuthoritiesConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/AuthoritiesConfigs.java
@@ -6,7 +6,7 @@ import io.tech1.framework.domain.properties.base.Authority;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/CookiesConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/CookiesConfigs.java
@@ -7,7 +7,7 @@ import io.tech1.framework.domain.properties.configs.AbstractPropertiesConfigs;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomString;
 import static java.time.temporal.ChronoUnit.SECONDS;

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/EssenceConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/EssenceConfigs.java
@@ -7,7 +7,7 @@ import io.tech1.framework.domain.properties.configs.AbstractPropertiesConfigs;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 // Lombok (property-based)
 @AllArgsConstructor(onConstructor = @__({@ConstructorBinding}))

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/IncidentsConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/IncidentsConfigs.java
@@ -8,7 +8,7 @@ import io.tech1.framework.domain.properties.base.SecurityJwtIncidentType;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import java.util.EnumMap;
 import java.util.Map;

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/JwtTokensConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/JwtTokensConfigs.java
@@ -11,7 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.asserts.Asserts.assertFalseOrThrow;
 import static io.tech1.framework.domain.constants.FrameworkLogsConstants.FRAMEWORK_PROPERTIES_PREFIX;

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/JwtTokensConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/JwtTokensConfigs.java
@@ -38,7 +38,7 @@ public class JwtTokensConfigs extends AbstractPropertiesConfigs {
 
     public static JwtTokensConfigs testsHardcoded() {
         return new JwtTokensConfigs(
-                "TECH1",
+                "nbVwWebIpNnZ1rsNZFmkAQGiOZAijWtSt5X6FZx/qHA=",
                 JwtTokenStorageMethod.COOKIES,
                 new JwtToken(new TimeAmount(30L, SECONDS), "ajwt", null),
                 new JwtToken(new TimeAmount(12L, HOURS), "rjwt", null)

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/LoggingConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/LoggingConfigs.java
@@ -5,7 +5,7 @@ import io.tech1.framework.domain.properties.base.AbstractPropertyConfigs;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 // Lombok (property-based)
 @AllArgsConstructor(onConstructor = @__({@ConstructorBinding}))

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/SessionConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/SessionConfigs.java
@@ -7,7 +7,7 @@ import io.tech1.framework.domain.properties.configs.AbstractPropertiesConfigs;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 // Lombok (property-based)
 @AllArgsConstructor(onConstructor = @__({@ConstructorBinding}))

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/UsersEmailsConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/UsersEmailsConfigs.java
@@ -6,7 +6,7 @@ import io.tech1.framework.domain.properties.configs.AbstractPropertiesConfigs;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomString;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/websockets/CsrfConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/websockets/CsrfConfigs.java
@@ -5,7 +5,7 @@ import io.tech1.framework.domain.properties.base.AbstractPropertyConfigs;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomString;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/websockets/MessageBrokerRegistryConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/websockets/MessageBrokerRegistryConfigs.java
@@ -5,7 +5,7 @@ import io.tech1.framework.domain.properties.base.AbstractPropertyConfigs;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomString;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/websockets/StompEndpointRegistryConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/websockets/StompEndpointRegistryConfigs.java
@@ -5,7 +5,7 @@ import io.tech1.framework.domain.properties.base.AbstractPropertyConfigs;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomString;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/websockets/WebsocketsFeatureHardwareConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/websockets/WebsocketsFeatureHardwareConfigs.java
@@ -6,7 +6,7 @@ import io.tech1.framework.domain.properties.base.AbstractTogglePropertyConfigs;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomBoolean;
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomString;

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/websockets/WebsocketsFeaturesConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/websockets/WebsocketsFeaturesConfigs.java
@@ -5,7 +5,7 @@ import io.tech1.framework.domain.properties.configs.AbstractPropertiesConfigs;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 // Lombok (property-based)
 @AllArgsConstructor(onConstructor = @__({@ConstructorBinding}))

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/websockets/WebsocketsTemplateConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/security/jwt/websockets/WebsocketsTemplateConfigs.java
@@ -5,7 +5,7 @@ import io.tech1.framework.domain.properties.base.AbstractTogglePropertyConfigs;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomBoolean;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/utilities/GeoCountryFlagsConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/utilities/GeoCountryFlagsConfigs.java
@@ -5,7 +5,7 @@ import io.tech1.framework.domain.properties.base.AbstractTogglePropertyConfigs;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomBoolean;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/utilities/GeoLocationsConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/utilities/GeoLocationsConfigs.java
@@ -5,7 +5,7 @@ import io.tech1.framework.domain.properties.base.AbstractPropertyConfigs;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomBoolean;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/utilities/UserAgentConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/properties/configs/utilities/UserAgentConfigs.java
@@ -5,7 +5,7 @@ import io.tech1.framework.domain.properties.base.AbstractTogglePropertyConfigs;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomBoolean;
 

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/tests/classes/NotUsedPropertiesConfigs.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/tests/classes/NotUsedPropertiesConfigs.java
@@ -8,7 +8,7 @@ import io.tech1.framework.domain.properties.configs.AbstractPropertiesConfigs;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 // Lombok (property-based)
 @AllArgsConstructor(onConstructor = @__({@ConstructorBinding}))

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/time/TimeAmount.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/time/TimeAmount.java
@@ -2,10 +2,10 @@ package io.tech1.framework.domain.time;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-import javax.validation.Constraint;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/utilities/http/HttpCookieUtility.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/utilities/http/HttpCookieUtility.java
@@ -4,8 +4,8 @@ import io.tech1.framework.domain.constants.StringConstants;
 import io.tech1.framework.domain.exceptions.cookies.CookieNotFoundException;
 import lombok.experimental.UtilityClass;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 
 import static io.tech1.framework.domain.utilities.exceptions.ExceptionsMessagesUtility.entityNotFound;

--- a/tech1-framework-domain/src/main/java/io/tech1/framework/domain/utilities/http/HttpServletRequestUtility.java
+++ b/tech1-framework-domain/src/main/java/io/tech1/framework/domain/utilities/http/HttpServletRequestUtility.java
@@ -3,7 +3,7 @@ package io.tech1.framework.domain.utilities.http;
 import io.tech1.framework.domain.http.requests.IPAddress;
 import lombok.experimental.UtilityClass;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import static io.tech1.framework.domain.utilities.exceptions.ExceptionsMessagesUtility.invalidAttribute;
 import static io.tech1.framework.domain.utilities.strings.StringUtility.hasLength;

--- a/tech1-framework-domain/src/test/java/io/tech1/framework/domain/http/requests/UserAgentHeaderTest.java
+++ b/tech1-framework-domain/src/test/java/io/tech1/framework/domain/http/requests/UserAgentHeaderTest.java
@@ -3,7 +3,7 @@ package io.tech1.framework.domain.http.requests;
 import io.tech1.framework.domain.utilities.random.RandomUtility;
 import org.junit.jupiter.api.Test;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -18,7 +18,7 @@ class UserAgentHeaderTest {
 
         // Assert
         assertThat(actual).isNotNull();
-        assertThat(actual.getValue()).isEmpty();;
+        assertThat(actual.getValue()).isEmpty();
     }
 
     @Test

--- a/tech1-framework-domain/src/test/java/io/tech1/framework/domain/utilities/http/HttpCookieUtilityTest.java
+++ b/tech1-framework-domain/src/test/java/io/tech1/framework/domain/utilities/http/HttpCookieUtilityTest.java
@@ -9,8 +9,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.stream.Stream;
 
 import static io.tech1.framework.domain.utilities.http.HttpCookieUtility.*;

--- a/tech1-framework-domain/src/test/java/io/tech1/framework/domain/utilities/http/HttpServletRequestUtilityTest.java
+++ b/tech1-framework-domain/src/test/java/io/tech1/framework/domain/utilities/http/HttpServletRequestUtilityTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.stream.Stream;
 
 import static io.tech1.framework.domain.utilities.http.HttpServletRequestUtility.getBaseURL;

--- a/tech1-framework-emails/src/main/java/io/tech1/framework/emails/configurations/ApplicationEmails.java
+++ b/tech1-framework-emails/src/main/java/io/tech1/framework/emails/configurations/ApplicationEmails.java
@@ -6,6 +6,7 @@ import io.tech1.framework.emails.services.impl.EmailServiceImpl;
 import io.tech1.framework.emails.utilities.EmailUtility;
 import io.tech1.framework.emails.utilities.impl.EmailUtilityImpl;
 import io.tech1.framework.properties.ApplicationFrameworkProperties;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,11 +14,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
-import org.thymeleaf.spring5.SpringTemplateEngine;
-import org.thymeleaf.spring5.templateresolver.SpringResourceTemplateResolver;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.thymeleaf.spring6.templateresolver.SpringResourceTemplateResolver;
 import org.thymeleaf.templatemode.TemplateMode;
 
-import javax.annotation.PostConstruct;
 import java.nio.charset.StandardCharsets;
 
 @Slf4j

--- a/tech1-framework-emails/src/main/java/io/tech1/framework/emails/services/impl/EmailServiceImpl.java
+++ b/tech1-framework-emails/src/main/java/io/tech1/framework/emails/services/impl/EmailServiceImpl.java
@@ -5,23 +5,23 @@ import io.tech1.framework.emails.domain.EmailPlainAttachment;
 import io.tech1.framework.emails.services.EmailService;
 import io.tech1.framework.emails.utilities.EmailUtility;
 import io.tech1.framework.properties.ApplicationFrameworkProperties;
+import jakarta.activation.DataHandler;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMultipart;
+import jakarta.mail.util.ByteArrayDataSource;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.thymeleaf.context.Context;
-import org.thymeleaf.spring5.SpringTemplateEngine;
+import org.thymeleaf.spring6.SpringTemplateEngine;
 
-import javax.activation.DataHandler;
-import javax.mail.MessagingException;
-import javax.mail.internet.MimeBodyPart;
-import javax.mail.internet.MimeMultipart;
-import javax.mail.util.ByteArrayDataSource;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
-import static javax.mail.Message.RecipientType.TO;
+import static jakarta.mail.Message.RecipientType.TO;
 
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class EmailServiceImpl implements EmailService {

--- a/tech1-framework-emails/src/main/java/io/tech1/framework/emails/utilities/EmailUtility.java
+++ b/tech1-framework-emails/src/main/java/io/tech1/framework/emails/utilities/EmailUtility.java
@@ -3,8 +3,8 @@ package io.tech1.framework.emails.utilities;
 import io.tech1.framework.domain.tuples.Tuple2;
 import org.springframework.mail.javamail.MimeMessageHelper;
 
-import javax.mail.MessagingException;
-import javax.mail.internet.MimeMessage;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 
 public interface EmailUtility {
     Tuple2<MimeMessage, MimeMessageHelper> getMimeMessageTuple2() throws MessagingException;

--- a/tech1-framework-emails/src/main/java/io/tech1/framework/emails/utilities/impl/EmailUtilityImpl.java
+++ b/tech1-framework-emails/src/main/java/io/tech1/framework/emails/utilities/impl/EmailUtilityImpl.java
@@ -7,8 +7,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 
-import javax.mail.MessagingException;
-import javax.mail.internet.MimeMessage;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.springframework.mail.javamail.MimeMessageHelper.MULTIPART_MODE_MIXED_RELATED;

--- a/tech1-framework-emails/src/test/java/io/tech1/framework/emails/services/impl/EmailServiceImplTest.java
+++ b/tech1-framework-emails/src/test/java/io/tech1/framework/emails/services/impl/EmailServiceImplTest.java
@@ -9,6 +9,9 @@ import io.tech1.framework.emails.domain.EmailPlainAttachment;
 import io.tech1.framework.emails.services.EmailService;
 import io.tech1.framework.emails.utilities.EmailUtility;
 import io.tech1.framework.properties.ApplicationFrameworkProperties;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,13 +27,10 @@ import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
-import org.thymeleaf.spring5.SpringTemplateEngine;
-import org.thymeleaf.spring5.templateresolver.SpringResourceTemplateResolver;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.thymeleaf.spring6.templateresolver.SpringResourceTemplateResolver;
 import org.thymeleaf.templatemode.TemplateMode;
 
-import javax.mail.MessagingException;
-import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMultipart;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -39,7 +39,7 @@ import java.util.Set;
 
 import static io.tech1.framework.domain.utilities.random.EntityUtility.entity;
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomString;
-import static javax.mail.Message.RecipientType.TO;
+import static jakarta.mail.Message.RecipientType.TO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 

--- a/tech1-framework-hardware/src/main/java/io/tech1/framework/hardware/configurations/ApplicationHardwareMonitoring.java
+++ b/tech1-framework-hardware/src/main/java/io/tech1/framework/hardware/configurations/ApplicationHardwareMonitoring.java
@@ -7,7 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 @Configuration
 @ComponentScan({

--- a/tech1-framework-incidents/src/main/java/io/tech1/framework/incidents/configurations/ApplicationAsyncIncidents.java
+++ b/tech1-framework-incidents/src/main/java/io/tech1/framework/incidents/configurations/ApplicationAsyncIncidents.java
@@ -13,7 +13,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.util.concurrent.Executor;
 
 import static io.tech1.framework.domain.utilities.processors.ProcessorsUtility.getHalfOfCores;

--- a/tech1-framework-incidents/src/main/java/io/tech1/framework/incidents/configurations/ApplicationEventsIncidents.java
+++ b/tech1-framework-incidents/src/main/java/io/tech1/framework/incidents/configurations/ApplicationEventsIncidents.java
@@ -3,6 +3,7 @@ package io.tech1.framework.incidents.configurations;
 import io.tech1.framework.domain.base.PropertyId;
 import io.tech1.framework.incidents.handlers.ErrorHandlerPublisher;
 import io.tech1.framework.properties.ApplicationFrameworkProperties;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -10,8 +11,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.ApplicationEventMulticaster;
 import org.springframework.context.event.SimpleApplicationEventMulticaster;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
-
-import javax.annotation.PostConstruct;
 
 import static io.tech1.framework.domain.utilities.processors.ProcessorsUtility.getHalfOfCores;
 import static io.tech1.framework.domain.utilities.processors.ProcessorsUtility.getNumOfCores;

--- a/tech1-framework-incidents/src/main/java/io/tech1/framework/incidents/configurations/ApplicationIncidents.java
+++ b/tech1-framework-incidents/src/main/java/io/tech1/framework/incidents/configurations/ApplicationIncidents.java
@@ -9,13 +9,12 @@ import io.tech1.framework.domain.base.PropertyId;
 import io.tech1.framework.incidents.feigns.definitions.IncidentClientDefinition;
 import io.tech1.framework.incidents.feigns.definitions.IncidentClientSlf4j;
 import io.tech1.framework.properties.ApplicationFrameworkProperties;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
-
-import javax.annotation.PostConstruct;
 
 @Slf4j
 @ComponentScan({

--- a/tech1-framework-incidents/src/test/java/io/tech1/framework/incidents/feigns/clients/impl/IncidentClientImplTest.java
+++ b/tech1-framework-incidents/src/test/java/io/tech1/framework/incidents/feigns/clients/impl/IncidentClientImplTest.java
@@ -31,7 +31,7 @@ class IncidentClientImplTest {
         }
 
         @Bean
-        IncidentClient incidentPublisher() {
+        IncidentClient incidentClient() {
             return new IncidentClientImpl(
                     this.incidentClientDefinition()
             );

--- a/tech1-framework-utilities/src/main/java/io/tech1/framework/utilities/configurations/ApplicationUtilities.java
+++ b/tech1-framework-utilities/src/main/java/io/tech1/framework/utilities/configurations/ApplicationUtilities.java
@@ -7,7 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 @Configuration
 @ComponentScan({

--- a/tech1-framework-utilities/src/test/java/io/tech1/framework/utilities/browsers/impl/UserAgentDetailsUtilityImplTest.java
+++ b/tech1-framework-utilities/src/test/java/io/tech1/framework/utilities/browsers/impl/UserAgentDetailsUtilityImplTest.java
@@ -18,7 +18,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.stream.Stream;
 
 import static io.tech1.framework.domain.utilities.random.RandomUtility.randomString;


### PR DESCRIPTION
- Оновив spring boot до версії 3.2.5. Оновив залежністі які є у нас та в [spring-boot-dependencies](https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies) до версій які в bom. Непотрібні залежності видалив
- Виправив помилки компіляції звʼязані зі змінами в Spring Security та Hibernate 6. Використав нові методи які були додані на заміну видаленим. Оновив тести
- Прибрав використання deprecated кода для Spring Web Security. Залишив клас ApplicationBaseSecurityJwtWebsockets без змін так як схоже по інформації з github повної заміни цьому класу ще не представили. При зміні по рекомендаціям зі документації - підключитися до сокетів не вийшло, можливо треба сидіти та довше покопати
- Оновив jjwt до 0.12.5. Довелось згенерувати новий HS265 ключ та оновити тести. Closes #2 