### PR TITLE
Remove Beans from SecurityJwtWebsockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
 ### Changelog [v3.0.3]
-— TBD
+— Modification: remove @Beans section from ApplicationBaseSecurityJwtWebsockets
+— Modification: move iam.assistants.current.base from ApplicationBaseSecurityJwt's ComponentScan to ApplicationIamServer
+— Modification: change io.tech1.framework.iam.services.impl to io.tech1.framework.iam.services.base and classes inside
+— Modification: create HardwareMonitoringSubscriberWebsockets only when ApplicationBaseSecurityJwtWebsockets bean present

--- a/tech1-framework-iam-server/src/main/java/io/tech1/framework/iam/server/configurations/ApplicationIamServer.java
+++ b/tech1-framework-iam-server/src/main/java/io/tech1/framework/iam/server/configurations/ApplicationIamServer.java
@@ -18,6 +18,7 @@ import org.springframework.security.config.annotation.web.builders.WebSecurity;
 @ComponentScan({
         // -------------------------------------------------------------------------------------------------------------
         "io.tech1.framework.iam.filters.jwt_extension",
+        "io.tech1.framework.iam.assistants.current.base"
         // -------------------------------------------------------------------------------------------------------------
 })
 @Import({

--- a/tech1-framework-iam/src/main/java/io/tech1/framework/iam/configurations/ApplicationBaseSecurityJwt.java
+++ b/tech1-framework-iam/src/main/java/io/tech1/framework/iam/configurations/ApplicationBaseSecurityJwt.java
@@ -34,7 +34,6 @@ import static org.springframework.http.HttpMethod.*;
 @Configuration
 @ComponentScan({
         // -------------------------------------------------------------------------------------------------------------
-        "io.tech1.framework.iam.assistants.current",
         "io.tech1.framework.iam.crons",
         "io.tech1.framework.iam.events",
         "io.tech1.framework.iam.handlers.exceptions",

--- a/tech1-framework-iam/src/main/java/io/tech1/framework/iam/configurations/ApplicationBaseSecurityJwt.java
+++ b/tech1-framework-iam/src/main/java/io/tech1/framework/iam/configurations/ApplicationBaseSecurityJwt.java
@@ -38,7 +38,7 @@ import static org.springframework.http.HttpMethod.*;
         "io.tech1.framework.iam.events",
         "io.tech1.framework.iam.handlers.exceptions",
         "io.tech1.framework.iam.resources",
-        "io.tech1.framework.iam.services.impl",
+        "io.tech1.framework.iam.services.base",
         "io.tech1.framework.iam.tokens",
         "io.tech1.framework.iam.utils",
         "io.tech1.framework.iam.validators.base"

--- a/tech1-framework-iam/src/main/java/io/tech1/framework/iam/configurations/ApplicationBaseSecurityJwtWebsockets.java
+++ b/tech1-framework-iam/src/main/java/io/tech1/framework/iam/configurations/ApplicationBaseSecurityJwtWebsockets.java
@@ -2,25 +2,14 @@ package io.tech1.framework.iam.configurations;
 
 import io.tech1.framework.foundation.domain.base.PropertyId;
 import io.tech1.framework.foundation.domain.properties.ApplicationFrameworkProperties;
-import io.tech1.framework.foundation.incidents.events.publishers.IncidentPublisher;
-import io.tech1.framework.foundation.services.hardware.store.HardwareMonitoringStore;
-import io.tech1.framework.iam.events.subscribers.websockets.HardwareMonitoringSubscriberWebsockets;
 import io.tech1.framework.iam.handshakes.CsrfInterceptorHandshake;
 import io.tech1.framework.iam.handshakes.SecurityHandshakeHandler;
-import io.tech1.framework.iam.services.TokensService;
-import io.tech1.framework.iam.sessions.SessionRegistry;
-import io.tech1.framework.iam.tasks.HardwareBackPressureTimerTask;
-import io.tech1.framework.iam.template.WssMessagingTemplate;
-import io.tech1.framework.iam.template.impl.WssMessagingTemplateImpl;
-import io.tech1.framework.iam.tokens.facade.TokensProvider;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Primary;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.security.config.annotation.web.messaging.MessageSecurityMetadataSourceRegistry;
 import org.springframework.security.config.annotation.web.socket.AbstractSecurityWebSocketMessageBrokerConfigurer;
@@ -45,6 +34,12 @@ import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 @Configuration
 @Import({
         ApplicationBaseSecurityJwt.class
+})
+@ComponentScan({
+        "io.tech1.framework.iam.events.subscribers.websockets",
+        "io.tech1.framework.iam.handshakes",
+        "io.tech1.framework.iam.tasks",
+        "io.tech1.framework.iam.template",
 })
 @EnableWebSocketMessageBroker
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -96,66 +91,4 @@ public class ApplicationBaseSecurityJwtWebsockets extends AbstractSecurityWebSoc
         return false;
     }
 
-    // =================================================================================================================
-    // @Beans
-    // =================================================================================================================
-    @Bean
-    CsrfInterceptorHandshake csrfInterceptorHandshake(
-            TokensProvider tokensProvider
-    ) {
-        return new CsrfInterceptorHandshake(tokensProvider);
-    }
-
-    @Bean
-    HardwareBackPressureTimerTask hardwareBackPressureTimerTask(
-            SessionRegistry sessionRegistry,
-            WssMessagingTemplate wssMessagingTemplate,
-            HardwareMonitoringStore hardwareMonitoringStore,
-            IncidentPublisher incidentPublisher
-    ) {
-        return new HardwareBackPressureTimerTask(
-                sessionRegistry,
-                wssMessagingTemplate,
-                hardwareMonitoringStore,
-                incidentPublisher,
-                this.applicationFrameworkProperties
-        );
-    }
-
-    @Primary
-    @Bean
-    HardwareMonitoringSubscriberWebsockets hardwareMonitoringSubscriberWebsockets(
-            HardwareMonitoringStore hardwareMonitoringStore,
-            HardwareBackPressureTimerTask hardwareBackPressureTimerTask,
-            IncidentPublisher incidentPublisher
-    ) {
-        return new HardwareMonitoringSubscriberWebsockets(
-                hardwareMonitoringStore,
-                hardwareBackPressureTimerTask,
-                incidentPublisher
-        );
-    }
-
-    @Bean
-    SecurityHandshakeHandler securityHandshakeHandler(
-            TokensService tokensService,
-            TokensProvider tokensProvider
-    ) {
-        return new SecurityHandshakeHandler(
-                tokensService,
-                tokensProvider
-        );
-    }
-
-    @Bean
-    WssMessagingTemplate wssMessagingTemplate(
-            SimpMessagingTemplate simpMessagingTemplate,
-            IncidentPublisher incidentPublisher
-    ) {
-        return new WssMessagingTemplateImpl(
-                simpMessagingTemplate,
-                incidentPublisher,
-                this.applicationFrameworkProperties
-        );
-    }
 }

--- a/tech1-framework-iam/src/main/java/io/tech1/framework/iam/events/subscribers/websockets/HardwareMonitoringSubscriberWebsockets.java
+++ b/tech1-framework-iam/src/main/java/io/tech1/framework/iam/events/subscribers/websockets/HardwareMonitoringSubscriberWebsockets.java
@@ -5,7 +5,11 @@ import io.tech1.framework.foundation.incidents.events.publishers.IncidentPublish
 import io.tech1.framework.foundation.services.hardware.store.HardwareMonitoringStore;
 import io.tech1.framework.foundation.services.hardware.subscribers.impl.BaseHardwareMonitoringSubscriber;
 import io.tech1.framework.iam.tasks.HardwareBackPressureTimerTask;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
 
+@Primary
+@Component
 public class HardwareMonitoringSubscriberWebsockets extends BaseHardwareMonitoringSubscriber {
 
     // TimerTasks

--- a/tech1-framework-iam/src/main/java/io/tech1/framework/iam/events/subscribers/websockets/HardwareMonitoringSubscriberWebsockets.java
+++ b/tech1-framework-iam/src/main/java/io/tech1/framework/iam/events/subscribers/websockets/HardwareMonitoringSubscriberWebsockets.java
@@ -4,11 +4,14 @@ import io.tech1.framework.foundation.domain.events.hardware.EventLastHardwareMon
 import io.tech1.framework.foundation.incidents.events.publishers.IncidentPublisher;
 import io.tech1.framework.foundation.services.hardware.store.HardwareMonitoringStore;
 import io.tech1.framework.foundation.services.hardware.subscribers.impl.BaseHardwareMonitoringSubscriber;
+import io.tech1.framework.iam.configurations.ApplicationBaseSecurityJwtWebsockets;
 import io.tech1.framework.iam.tasks.HardwareBackPressureTimerTask;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 @Primary
+@ConditionalOnBean(ApplicationBaseSecurityJwtWebsockets.class)
 @Component
 public class HardwareMonitoringSubscriberWebsockets extends BaseHardwareMonitoringSubscriber {
 

--- a/tech1-framework-iam/src/main/java/io/tech1/framework/iam/handshakes/CsrfInterceptorHandshake.java
+++ b/tech1-framework-iam/src/main/java/io/tech1/framework/iam/handshakes/CsrfInterceptorHandshake.java
@@ -10,12 +10,14 @@ import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.HandshakeInterceptor;
 
 import java.util.Map;
 
 @Slf4j
+@Component
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class CsrfInterceptorHandshake implements HandshakeInterceptor {
 

--- a/tech1-framework-iam/src/main/java/io/tech1/framework/iam/handshakes/SecurityHandshakeHandler.java
+++ b/tech1-framework-iam/src/main/java/io/tech1/framework/iam/handshakes/SecurityHandshakeHandler.java
@@ -9,12 +9,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
 
 import java.security.Principal;
 import java.util.Map;
 
+@Component
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class SecurityHandshakeHandler extends DefaultHandshakeHandler {
 

--- a/tech1-framework-iam/src/main/java/io/tech1/framework/iam/resources/BaseSecurityAuthenticationResource.java
+++ b/tech1-framework-iam/src/main/java/io/tech1/framework/iam/resources/BaseSecurityAuthenticationResource.java
@@ -34,7 +34,6 @@ import static java.util.Objects.nonNull;
 // Swagger
 @Tag(name = "[tech1-framework] Authentication API")
 // Spring
-@SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
 @Slf4j
 @AbstractFrameworkBaseSecurityResource
 @RestController

--- a/tech1-framework-iam/src/main/java/io/tech1/framework/iam/services/base/BaseTokensService.java
+++ b/tech1-framework-iam/src/main/java/io/tech1/framework/iam/services/base/BaseTokensService.java
@@ -1,4 +1,4 @@
-package io.tech1.framework.iam.services.impl;
+package io.tech1.framework.iam.services.base;
 
 import io.tech1.framework.iam.assistants.userdetails.JwtUserDetailsService;
 import io.tech1.framework.iam.domain.dto.responses.ResponseRefreshTokens;
@@ -20,11 +20,10 @@ import org.springframework.stereotype.Service;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-@SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
 @Slf4j
 @Service
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
-public class TokensServiceImpl implements TokensService {
+public class BaseTokensService implements TokensService {
 
     // Assistants
     private final JwtUserDetailsService jwtUserDetailsService;

--- a/tech1-framework-iam/src/main/java/io/tech1/framework/iam/services/base/BaseUsersEmailsService.java
+++ b/tech1-framework-iam/src/main/java/io/tech1/framework/iam/services/base/BaseUsersEmailsService.java
@@ -1,4 +1,4 @@
-package io.tech1.framework.iam.services.impl;
+package io.tech1.framework.iam.services.base;
 
 import io.tech1.framework.iam.domain.enums.AccountAccessMethod;
 import io.tech1.framework.iam.domain.functions.FunctionAuthenticationLoginEmail;
@@ -23,7 +23,7 @@ import static java.util.Objects.nonNull;
 
 @Service
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
-public class UsersEmailsServiceImpl implements UsersEmailsService {
+public class BaseUsersEmailsService implements UsersEmailsService {
 
     // Services
     private final EmailService emailService;

--- a/tech1-framework-iam/src/main/java/io/tech1/framework/iam/tasks/HardwareBackPressureTimerTask.java
+++ b/tech1-framework-iam/src/main/java/io/tech1/framework/iam/tasks/HardwareBackPressureTimerTask.java
@@ -7,11 +7,13 @@ import io.tech1.framework.foundation.incidents.events.publishers.IncidentPublish
 import io.tech1.framework.foundation.services.hardware.store.HardwareMonitoringStore;
 import io.tech1.framework.iam.sessions.SessionRegistry;
 import io.tech1.framework.iam.template.WssMessagingTemplate;
+import org.springframework.stereotype.Component;
 
 import java.util.concurrent.TimeUnit;
 
 import static io.tech1.framework.iam.domain.events.WebsocketEvent.hardwareMonitoring;
 
+@Component
 public class HardwareBackPressureTimerTask extends AbstractInfiniteTimerTask {
 
     // Sessions

--- a/tech1-framework-iam/src/main/java/io/tech1/framework/iam/template/impl/WssMessagingTemplateImpl.java
+++ b/tech1-framework-iam/src/main/java/io/tech1/framework/iam/template/impl/WssMessagingTemplateImpl.java
@@ -9,7 +9,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
 
+@Component
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class WssMessagingTemplateImpl implements WssMessagingTemplate {
 

--- a/tech1-framework-iam/src/test/java/io/tech1/framework/iam/services/base/BaseTokensServiceTest.java
+++ b/tech1-framework-iam/src/test/java/io/tech1/framework/iam/services/base/BaseTokensServiceTest.java
@@ -1,4 +1,4 @@
-package io.tech1.framework.iam.services.impl;
+package io.tech1.framework.iam.services.base;
 
 import io.tech1.framework.iam.assistants.userdetails.JwtUserDetailsService;
 import io.tech1.framework.iam.domain.dto.responses.ResponseRefreshTokens;
@@ -6,7 +6,6 @@ import io.tech1.framework.iam.domain.jwt.*;
 import io.tech1.framework.iam.services.BaseUsersSessionsService;
 import io.tech1.framework.iam.services.TokensContextThrowerService;
 import io.tech1.framework.iam.services.TokensService;
-import io.tech1.framework.iam.services.impl.TokensServiceImpl;
 import io.tech1.framework.iam.sessions.SessionRegistry;
 import io.tech1.framework.iam.tokens.facade.TokensProvider;
 import io.tech1.framework.iam.utils.SecurityJwtTokenUtils;
@@ -37,7 +36,7 @@ import static org.mockito.Mockito.*;
 @ExtendWith({ SpringExtension.class })
 @ContextConfiguration(loader= AnnotationConfigContextLoader.class)
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
-class TokensServiceImplTest {
+class BaseTokensServiceTest {
 
     @Configuration
     @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -74,7 +73,7 @@ class TokensServiceImplTest {
 
         @Bean
         TokensService tokenService() {
-            return new TokensServiceImpl(
+            return new BaseTokensService(
                     this.jwtUserDetailsAssistant(),
                     this.sessionRegistry(),
                     this.tokenContextThrowerService(),

--- a/tech1-framework-iam/src/test/java/io/tech1/framework/iam/services/base/BaseUsersEmailsServiceTest.java
+++ b/tech1-framework-iam/src/test/java/io/tech1/framework/iam/services/base/BaseUsersEmailsServiceTest.java
@@ -1,10 +1,9 @@
-package io.tech1.framework.iam.services.impl;
+package io.tech1.framework.iam.services.base;
 
 import io.tech1.framework.iam.domain.enums.AccountAccessMethod;
 import io.tech1.framework.iam.domain.functions.FunctionAuthenticationLoginEmail;
 import io.tech1.framework.iam.domain.functions.FunctionSessionRefreshedEmail;
 import io.tech1.framework.iam.services.UsersEmailsService;
-import io.tech1.framework.iam.services.impl.UsersEmailsServiceImpl;
 import io.tech1.framework.iam.utils.UserEmailUtils;
 import io.tech1.framework.foundation.domain.base.Email;
 import io.tech1.framework.foundation.domain.base.Username;
@@ -35,7 +34,7 @@ import static org.mockito.Mockito.*;
 @ExtendWith({ SpringExtension.class })
 @ContextConfiguration(loader= AnnotationConfigContextLoader.class)
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
-class UsersEmailsServiceImplTest {
+class BaseUsersEmailsServiceTest {
 
     @Configuration
     @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -57,7 +56,7 @@ class UsersEmailsServiceImplTest {
 
         @Bean
         public UsersEmailsService userEmailService() {
-            return new UsersEmailsServiceImpl(
+            return new BaseUsersEmailsService(
                     this.emailService(),
                     this.userEmailUtility(),
                     this.applicationFrameworkProperties()


### PR DESCRIPTION
- remove `@Beans` section from `ApplicationBaseSecurityJwtWebsockets`
- move `iam.assistants.current.base` from `ApplicationBaseSecurityJwt`'s `ComponentScan` to `ApplicationIamServer`
- change `io.tech1.framework.iam.services.impl` to `io.tech1.framework.iam.services.base` and classes inside
- create `HardwareMonitoringSubscriberWebsockets` only when `ApplicationBaseSecurityJwtWebsockets` bean present