### PR TITLE
Handle Exception.class errors in ControllerAdvice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 ### Changelog [v3.0.7]
-— TBD
+— Modification: add Exception.class errors handling
+— Modification: add HIGHEST_PRECEDENCE order to ControllerAdvice handler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 ### Changelog [v3.0.7]
 — Modification: add Exception.class errors handling
-— Modification: add HIGHEST_PRECEDENCE order to ControllerAdvice handler
+— Modification: add LOWEST_PRECEDENCE order to ControllerAdvice handler

--- a/tech1-framework-iam/src/main/java/io/tech1/framework/iam/handlers/exceptions/ResourceExceptionHandler.java
+++ b/tech1-framework-iam/src/main/java/io/tech1/framework/iam/handlers/exceptions/ResourceExceptionHandler.java
@@ -8,7 +8,6 @@ import io.tech1.framework.foundation.domain.exceptions.tokens.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,7 +21,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import static io.tech1.framework.foundation.utilities.exceptions.ExceptionsMessagesUtility.contactDevelopmentTeam;
 
 @Slf4j
-@Order(Ordered.HIGHEST_PRECEDENCE)
+@Order
 @ControllerAdvice
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class ResourceExceptionHandler {

--- a/tech1-framework-iam/src/main/java/io/tech1/framework/iam/handlers/exceptions/ResourceExceptionHandler.java
+++ b/tech1-framework-iam/src/main/java/io/tech1/framework/iam/handlers/exceptions/ResourceExceptionHandler.java
@@ -22,8 +22,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import static io.tech1.framework.foundation.utilities.exceptions.ExceptionsMessagesUtility.contactDevelopmentTeam;
 
 @Slf4j
-@ControllerAdvice
 @Order(Ordered.HIGHEST_PRECEDENCE)
+@ControllerAdvice
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class ResourceExceptionHandler {
 

--- a/tech1-framework-iam/src/main/java/io/tech1/framework/iam/handlers/exceptions/ResourceExceptionHandler.java
+++ b/tech1-framework-iam/src/main/java/io/tech1/framework/iam/handlers/exceptions/ResourceExceptionHandler.java
@@ -8,6 +8,8 @@ import io.tech1.framework.foundation.domain.exceptions.tokens.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageConversionException;
@@ -21,6 +23,7 @@ import static io.tech1.framework.foundation.utilities.exceptions.ExceptionsMessa
 
 @Slf4j
 @ControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class ResourceExceptionHandler {
 
@@ -97,5 +100,19 @@ public class ResourceExceptionHandler {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ResponseEntity<ExceptionEntity> internalServerError(Exception ex) {
         return new ResponseEntity<>(new ExceptionEntity(ex), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler({
+            Exception.class
+    })
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ResponseEntity<ExceptionEntity> generalException(Exception ex) {
+        LOGGER.error("Unexpected error occurred", ex);
+        var response = new ExceptionEntity(
+                ExceptionEntityType.ERROR,
+                contactDevelopmentTeam("An unexpected error occurred"),
+                ex.getMessage()
+        );
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/tech1-framework-iam/src/main/java/io/tech1/framework/iam/handlers/exceptions/ResourceExceptionHandler.java
+++ b/tech1-framework-iam/src/main/java/io/tech1/framework/iam/handlers/exceptions/ResourceExceptionHandler.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 import static io.tech1.framework.foundation.utilities.exceptions.ExceptionsMessagesUtility.contactDevelopmentTeam;
 
+// WARNING: @Order by default uses Ordered.LOWEST_PRECEDENCE
 @Slf4j
 @Order
 @ControllerAdvice


### PR DESCRIPTION
Дододав хендлер для `Exception.class` помилок, щоб сервер не повертав 401 коли під час запиту падає виключення яке не хедлиться.

Додав анотацію `@Order` до `ResourceExceptionHandler`. По замовчуванню анотація має значення `LOWEST_PRECEDENCE`. 

Проекти які використовують фреймворк мають додати до свого `@ControllerAdvice` анотацію `@Order(Ordered.HIGHEST_PRECEDENCE)` або `@Order(Ordered.LOWEST_PRECEDENCE - 1)` якщо очікують що їхню логіку обробки виключень хтось захоче переписати.